### PR TITLE
Support infinite service idle timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The solution allows setting GPU load factors. This is a multiplicative coefficie
 
 The `slurm-quota set-gpu-factor` command allows configuring load factors by GPU type (restricted to root). The `slurm-quota gpu-factors` command displays the currently configured GPU load factors.
 
-The `slurm-quota serve` command starts a small HTTP/JSON server designed to work with systemd "socket activation". A `slurm-quota.socket` socket unit listens on TCP port 9911 and launches the `slurm-quota.service` service on demand upon the first connection. The server automatically stops after a configurable period of inactivity (10 minutes by default). The API exposes a single `/stats` route that returns a JSON object of the form `{ users: [...], accounts: [...] }`. When the `username` parameter is provided (e.g. `/stats?username=alice`), the server filters accounts server-side to only the Slurm associations of this user.
+The `slurm-quota serve` command starts a small HTTP/JSON server designed to work with systemd "socket activation". A `slurm-quota.socket` socket unit listens on TCP port 9911 and launches the `slurm-quota.service` service on demand upon the first connection. The server can automatically stops after a configurable period of inactivity (10 minutes by default). The API exposes a single `/stats` route that returns a JSON object of the form `{ users: [...], accounts: [...] }`. When the `username` parameter is provided (e.g. `/stats?username=alice`), the server filters accounts server-side to only the Slurm associations of this user.
 
 The `slurm-quota stats` command consumes this HTTP/JSON API by default (URL configurable via the `SLURM_QUOTA_URL` environment variable, default `http://127.0.0.1:9911/`). It queries `/stats` and displays a readable table in the terminal. By specifying a username or the `--all` option, the command transmits the appropriate filters to the service. If the service is not available or in case of connection failure to the server, execution fails with an error message.
 
@@ -107,7 +107,7 @@ sudo systemctl status slurm-quota.socket
 curl http://127.0.0.1:9911/health
 ```
 
-The service automatically stops after 10 minutes of inactivity (configurable via `--idle-timeout`).
+The service automatically stops after 10 minutes of inactivity (configurable via `--idle-timeout` in `slurm-quota.service`, with `0` meaning no idle timeout).
 
 5) Installation of the wrapper script
 
@@ -191,6 +191,7 @@ Examples:
 ```bash
 # Manual launch (testing)
 slurm-quota serve --host 127.0.0.1 --port 9911 --idle-timeout 600
+slurm-quota serve --host 127.0.0.1 --port 9911 --idle-timeout 0    # no idle timeout
 
 # Via systemd (recommended)
 sudo systemctl start slurm-quota.socket
@@ -199,7 +200,7 @@ curl http://127.0.0.1:9911/stats
 curl http://127.0.0.1:9911/stats?username=alice
 ```
 
-The service automatically stops after a period of inactivity (10 minutes by default). The `stats` command queries this HTTP service (URL configurable via the `SLURM_QUOTA_URL` environment variable).
+The service automatically stops after a period of inactivity (600 seconds, ie. 10 minutes by default). This can be disabled with `--idle-timeout 0` argument. The `stats` command queries this HTTP service (URL configurable via the `SLURM_QUOTA_URL` environment variable).
 
 - `user-quota` (restricted to root): Sets a CPU quota for a user.
 

--- a/slurm-quota
+++ b/slurm-quota
@@ -1318,7 +1318,9 @@ class _RequestHandler(BaseHTTPRequestHandler):
 class InactivityHTTPServer(HTTPServer):
     def __init__(self, server_address, RequestHandlerClass, idle_timeout: int = 600):
         super().__init__(server_address, RequestHandlerClass)
-        self._idle_timeout = max(1, int(idle_timeout))
+        # Get idle timeout from command line or environment variable. Special value 0
+        # disables idle shutdown (infinite timeout).
+        self._idle_timeout = max(0, int(idle_timeout))
         self._last_activity = time.monotonic()
 
     def touch_activity(self) -> None:
@@ -1329,6 +1331,10 @@ class InactivityHTTPServer(HTTPServer):
         while True:
             # handle_request() blocks up to self.timeout
             self.handle_request()
+            # If idle timeout is disabled, continue to the next iteration.
+            if self._idle_timeout == 0:
+                continue
+            # If idle timeout is enabled, check if the last activity was too long ago.
             if time.monotonic() - self._last_activity > self._idle_timeout:
                 logger.info("Idle timeout reached; exiting")
                 break
@@ -1734,7 +1740,7 @@ def main():
         "--idle-timeout",
         type=int,
         default=600,
-        help="Exit after N seconds of inactivity (default: 600)",
+        help="Exit after N seconds of inactivity (0 disables idle timeout; default: 600)",
     )
 
     args = parser.parse_args()

--- a/tests/functional/test_serve.py
+++ b/tests/functional/test_serve.py
@@ -2,26 +2,206 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+import http.client
+import json
+import os
+import socket
+import threading
+import time
 
 from tests.functional.functional_base import FunctionalCLIBase
 
 
 class TestServeCommand(FunctionalCLIBase):
-    def test_serve_passes_host_port_idle_timeout(self):
-        self.init_db()
-        mock_run = MagicMock()
-        with patch.object(self.sq, "run_serve_command", mock_run):
-            self.run_main(
+    def _free_tcp_port(self) -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            return int(s.getsockname()[1])
+
+    def _start_serve_thread(
+        self, host: str, port: int, idle_timeout: int = 1
+    ) -> threading.Thread:
+        thread = threading.Thread(
+            target=self.run_main,
+            args=(
                 [
                     "slurm-quota",
                     "serve",
                     "--host",
-                    "0.0.0.0",
+                    host,
                     "--port",
-                    "12345",
+                    str(port),
                     "--idle-timeout",
-                    "42",
-                ]
+                    str(idle_timeout),
+                ],
+            ),
+            daemon=True,
+        )
+        thread.start()
+        return thread
+
+    def _wait_until_ready(self, host: str, port: int) -> None:
+        deadline = time.monotonic() + 2.0
+        while True:
+            conn = None
+            try:
+                conn = http.client.HTTPConnection(host, port, timeout=1)
+                conn.request("GET", "/health")
+                resp = conn.getresponse()
+                self.assertEqual(resp.status, 200)
+                self.assertEqual(
+                    json.loads(resp.read().decode("utf-8")),
+                    {"status": "ok"},
+                )
+                return
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(0.05)
+            finally:
+                try:
+                    if conn is not None:
+                        conn.close()
+                except Exception:
+                    pass
+
+    def _join_after_idle(self, thread: threading.Thread) -> None:
+        thread.join(timeout=3)
+        self.assertFalse(thread.is_alive())
+
+    def test_serve_get_health_returns_ok(self):
+        self.init_db()
+        host = "127.0.0.1"
+        port = self._free_tcp_port()
+        thread = self._start_serve_thread(host, port)
+        self._wait_until_ready(host, port)
+
+        conn = http.client.HTTPConnection(host, port, timeout=2)
+        try:
+            conn.request("GET", "/health")
+            resp = conn.getresponse()
+            self.assertEqual(resp.status, 200)
+            self.assertEqual(
+                json.loads(resp.read().decode("utf-8")),
+                {"status": "ok"},
             )
-        mock_run.assert_called_once_with("0.0.0.0", 12345, 42)
+        finally:
+            conn.close()
+
+        self._join_after_idle(thread)
+
+    def test_serve_get_stats_returns_users_and_accounts(self):
+        self.init_db()
+        host = "127.0.0.1"
+        port = self._free_tcp_port()
+        thread = self._start_serve_thread(host, port)
+        self._wait_until_ready(host, port)
+
+        conn = http.client.HTTPConnection(host, port, timeout=2)
+        try:
+            conn.request("GET", "/stats")
+            resp = conn.getresponse()
+            self.assertEqual(resp.status, 200)
+            body = json.loads(resp.read().decode("utf-8"))
+            self.assertIn("users", body)
+            self.assertIn("accounts", body)
+        finally:
+            conn.close()
+
+        self._join_after_idle(thread)
+
+    def test_serve_get_unknown_path_returns_not_found(self):
+        self.init_db()
+        host = "127.0.0.1"
+        port = self._free_tcp_port()
+        thread = self._start_serve_thread(host, port)
+        self._wait_until_ready(host, port)
+
+        conn = http.client.HTTPConnection(host, port, timeout=2)
+        try:
+            conn.request("GET", "/does-not-exist")
+            resp = conn.getresponse()
+            self.assertEqual(resp.status, 404)
+            self.assertEqual(
+                json.loads(resp.read().decode("utf-8")),
+                {"error": "not_found"},
+            )
+        finally:
+            conn.close()
+
+        self._join_after_idle(thread)
+
+    def test_serve_uses_systemd_socket_activation_env(self):
+        self.init_db()
+        host = "127.0.0.1"
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind((host, 0))
+        listener.listen(16)
+        port = int(listener.getsockname()[1])
+
+        fd3_backup = None
+        had_fd3 = True
+        try:
+            try:
+                os.fstat(3)
+            except OSError:
+                had_fd3 = False
+            if had_fd3:
+                fd3_backup = os.dup(3)
+
+            os.dup2(listener.fileno(), 3)
+            self.env({"LISTEN_PID": str(os.getpid()), "LISTEN_FDS": "1"})
+
+            thread = self._start_serve_thread("0.0.0.0", 1, idle_timeout=1)
+            self._wait_until_ready(host, port)
+
+            conn = http.client.HTTPConnection(host, port, timeout=2)
+            try:
+                conn.request("GET", "/health")
+                resp = conn.getresponse()
+                self.assertEqual(resp.status, 200)
+                self.assertEqual(
+                    json.loads(resp.read().decode("utf-8")),
+                    {"status": "ok"},
+                )
+            finally:
+                conn.close()
+
+            self._join_after_idle(thread)
+        finally:
+            listener.close()
+            if fd3_backup is not None:
+                os.dup2(fd3_backup, 3)
+                os.close(fd3_backup)
+            elif not had_fd3:
+                try:
+                    os.close(3)
+                except OSError:
+                    pass
+
+    def test_serve_idle_timeout_zero_disables_shutdown(self):
+        self.init_db()
+        host = "127.0.0.1"
+        port = self._free_tcp_port()
+        thread = threading.Thread(
+            target=self.run_main,
+            args=(
+                [
+                    "slurm-quota",
+                    "serve",
+                    "--host",
+                    host,
+                    "--port",
+                    str(port),
+                    "--idle-timeout",
+                    "0",
+                ],
+            ),
+            daemon=True,
+        )
+        thread.start()
+
+        self._wait_until_ready(host, port)
+        time.sleep(1.2)
+        self.assertTrue(thread.is_alive())


### PR DESCRIPTION
Just set --idle-timeout 0 in argument of slurm-quota serve.

fix #1