### PR TITLE
Add slurm-quota stats --hours option

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,11 @@ Examples:
 slurm-quota stats                 # displays the current user and their accounts
 slurm-quota stats alice           # details for user alice and their accounts
 slurm-quota stats --all           # lists all users and all accounts
+slurm-quota stats --hours         # same stats displayed in hours
 ```
 
 Color display of the status bar can be disabled by setting the `NO_COLOR` environment variable.
+The `--hours` option changes only the displayed unit in the `stats` output; stored values and API values remain in minutes.
 
 - `serve`: Launches an HTTP JSON server to expose statistics via a REST API. Designed to work with systemd socket activation.
 

--- a/slurm-quota
+++ b/slurm-quota
@@ -968,7 +968,9 @@ def create_status_bar(used: int, total: int, width: int = 20) -> str:
     return f"[{colored_bar}] {percentage:6.1%}"
 
 
-def show_user_stats(username: Optional[str] = None, show_all: bool = False) -> None:
+def show_user_stats(
+    username: Optional[str] = None, show_all: bool = False, display_hours: bool = False
+) -> None:
     """
     Display resource statistics for users in table format.
 
@@ -1016,6 +1018,11 @@ def show_user_stats(username: Optional[str] = None, show_all: bool = False) -> N
                 print("No users found in service")
             return
 
+        def format_value(value_minutes: int) -> str:
+            if display_hours:
+                return f"{value_minutes / 60:.2f}"
+            return f"{value_minutes}"
+
         # Print users table
         header = (
             f"{'':<25} | {'CPU':^66} | {'GPU':^66} |\n"
@@ -1040,9 +1047,10 @@ def show_user_stats(username: Optional[str] = None, show_all: bool = False) -> N
                 cpu_quota_str = "∞"
                 cpu_status_bar = ""
             else:
-                cpu_quota_str = f"{cpu_quota}"
+                cpu_quota_str = format_value(cpu_quota)
                 cpu_status_bar = create_status_bar(cpu_total_used, cpu_quota)
-            cpu_preallocated_str = f"{cpu_preallocated}({job_count})"
+            cpu_consumed_str = format_value(cpu_consumed)
+            cpu_preallocated_str = f"{format_value(cpu_preallocated)}({job_count})"
 
             # GPU data
             gpu_consumed = int(item.get("total_consumed_gpu_minutes", 0))
@@ -1053,13 +1061,14 @@ def show_user_stats(username: Optional[str] = None, show_all: bool = False) -> N
                 gpu_quota_str = "∞"
                 gpu_status_bar = ""
             else:
-                gpu_quota_str = f"{gpu_quota}"
+                gpu_quota_str = format_value(gpu_quota)
                 gpu_status_bar = create_status_bar(gpu_total_used, gpu_quota)
-            gpu_preallocated_str = f"{gpu_preallocated}({job_count})"
+            gpu_consumed_str = format_value(gpu_consumed)
+            gpu_preallocated_str = f"{format_value(gpu_preallocated)}({job_count})"
 
             print(
-                f"{uname:<25} | {cpu_consumed:>11} {cpu_preallocated_str:>15} {cpu_quota_str:>8} {cpu_status_bar:<29} "
-                f"| {gpu_consumed:>11} {gpu_preallocated_str:>15} {gpu_quota_str:>8} {gpu_status_bar:<29} | {last_updated_str:<25}"
+                f"{uname:<25} | {cpu_consumed_str:>11} {cpu_preallocated_str:>15} {cpu_quota_str:>8} {cpu_status_bar:<29} "
+                f"| {gpu_consumed_str:>11} {gpu_preallocated_str:>15} {gpu_quota_str:>8} {gpu_status_bar:<29} | {last_updated_str:<25}"
             )
 
         # Accounts table
@@ -1087,9 +1096,10 @@ def show_user_stats(username: Optional[str] = None, show_all: bool = False) -> N
                 cpu_quota_str = "∞"
                 cpu_status_bar = " " * 25
             else:
-                cpu_quota_str = f"{cpu_quota}"
+                cpu_quota_str = format_value(cpu_quota)
                 cpu_status_bar = create_status_bar(cpu_total_used, cpu_quota)
-            cpu_preallocated_str = f"{cpu_preallocated}({job_count})"
+            cpu_consumed_str = format_value(cpu_consumed)
+            cpu_preallocated_str = f"{format_value(cpu_preallocated)}({job_count})"
 
             # GPU data
             gpu_consumed = int(item.get("total_consumed_gpu_minutes", 0))
@@ -1100,13 +1110,14 @@ def show_user_stats(username: Optional[str] = None, show_all: bool = False) -> N
                 gpu_quota_str = "∞"
                 gpu_status_bar = " " * 25
             else:
-                gpu_quota_str = f"{gpu_quota}"
+                gpu_quota_str = format_value(gpu_quota)
                 gpu_status_bar = create_status_bar(gpu_total_used, gpu_quota)
-            gpu_preallocated_str = f"{gpu_preallocated}({job_count})"
+            gpu_consumed_str = format_value(gpu_consumed)
+            gpu_preallocated_str = f"{format_value(gpu_preallocated)}({job_count})"
 
             print(
-                f"{account:<25} | {cpu_consumed:>11} {cpu_preallocated_str:>15} {cpu_quota_str:>8} {cpu_status_bar:<29} "
-                f"| {gpu_consumed:>11} {gpu_preallocated_str:>15} {gpu_quota_str:>8} {gpu_status_bar:<29} | {last_updated_str:<25}"
+                f"{account:<25} | {cpu_consumed_str:>11} {cpu_preallocated_str:>15} {cpu_quota_str:>8} {cpu_status_bar:<29} "
+                f"| {gpu_consumed_str:>11} {gpu_preallocated_str:>15} {gpu_quota_str:>8} {gpu_status_bar:<29} | {last_updated_str:<25}"
             )
     except URLError as e:
         logger.error(f"Failed to contact slurm-quota service: {e}")
@@ -1658,6 +1669,11 @@ def main():
         action="store_true",
         help="Show all users (same as not specifying username)",
     )
+    stats_parser.add_argument(
+        "--hours",
+        action="store_true",
+        help="Display stats values in hours instead of minutes",
+    )
 
     # User-quota command
     user_quota_parser = subparsers.add_parser(
@@ -1751,7 +1767,7 @@ def main():
     if args.command == "charge":
         charge_command()
     elif args.command == "stats":
-        show_user_stats(args.username, args.all)
+        show_user_stats(args.username, args.all, args.hours)
     elif args.command == "user-quota":
         set_user_quota_command(args.username, args.quota)
     elif args.command == "account-quota":

--- a/slurm-quota
+++ b/slurm-quota
@@ -968,6 +968,52 @@ def create_status_bar(used: int, total: int, width: int = 20) -> str:
     return f"[{colored_bar}] {percentage:6.1%}"
 
 
+class StatsHTTPError(Exception):
+    """Raised when the stats HTTP endpoint returns a non-success status."""
+
+    def __init__(self, status: int):
+        self.status = status
+        super().__init__(f"HTTP {status}")
+
+
+def fetch_stats_from_service(
+    selected_username: Optional[str], show_all: bool
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """
+    Request /stats from the slurm-quota HTTP service and return user and account rows.
+
+    Uses environment variable SLURM_QUOTA_URL as the service root, defaulting to
+    http://127.0.0.1:9911/.
+
+    Args:
+        selected_username: User filter when not show_all (may be None if show_all).
+        show_all: If True, do not add a username query parameter.
+
+    Returns:
+        (users_data, accounts_data) lists from the JSON payload.
+
+    Raises:
+        StatsHTTPError: Response status was not HTTP OK.
+        URLError: Network or URL handling failure from urlopen.
+    """
+    base_url = os.environ.get("SLURM_QUOTA_URL", "http://127.0.0.1:9911/")
+    stats_params: Dict[str, str] = {}
+    if selected_username and not show_all:
+        stats_params["username"] = selected_username
+    stats_url = urljoin(base_url, "stats")
+    if stats_params:
+        stats_url = f"{stats_url}?{urlencode(stats_params)}"
+
+    with urlopen(Request(stats_url, headers={"Accept": "application/json"})) as resp:
+        if resp.status != HTTPStatus.OK:
+            raise StatsHTTPError(resp.status)
+        stats_payload: Dict[str, Any] = json.load(resp)
+
+    users_data: List[Dict[str, Any]] = list(stats_payload.get("users", []))
+    accounts_data: List[Dict[str, Any]] = list(stats_payload.get("accounts", []))
+    return users_data, accounts_data
+
+
 def show_user_stats(
     username: Optional[str] = None, show_all: bool = False, display_hours: bool = False
 ) -> None:
@@ -978,9 +1024,6 @@ def show_user_stats(
         username: The username to query (if None and not show_all, shows all)
         show_all: If True, show all users
     """
-    # HTTP JSON service location
-    base_url = os.environ.get("SLURM_QUOTA_URL", "http://127.0.0.1:9911/")
-
     # Determine target username
     selected_username = username
     if not show_all and not selected_username:
@@ -989,27 +1032,10 @@ def show_user_stats(
         except KeyError:
             sys.exit(1)
 
-    # Fetch stats (users and accounts)
     try:
-        # Build stats URL with optional username parameter
-        stats_params: Dict[str, str] = {}
-        if selected_username and not show_all:
-            stats_params["username"] = selected_username
-        stats_url = urljoin(base_url, "stats")
-        if stats_params:
-            stats_url = f"{stats_url}?{urlencode(stats_params)}"
-
-        # Fetch stats from HTTP JSON service
-        with urlopen(
-            Request(stats_url, headers={"Accept": "application/json"})
-        ) as resp:
-            if resp.status != HTTPStatus.OK:
-                logger.error(f"Failed to fetch stats: HTTP {resp.status}")
-                sys.exit(1)
-            stats_payload: Dict[str, Any] = json.load(resp)
-
-        users_data: List[Dict[str, Any]] = list(stats_payload.get("users", []))
-        accounts_data: List[Dict[str, Any]] = list(stats_payload.get("accounts", []))
+        users_data, accounts_data = fetch_stats_from_service(
+            selected_username, show_all
+        )
 
         if not users_data:
             if username:
@@ -1119,6 +1145,9 @@ def show_user_stats(
                 f"{account:<25} | {cpu_consumed_str:>11} {cpu_preallocated_str:>15} {cpu_quota_str:>8} {cpu_status_bar:<29} "
                 f"| {gpu_consumed_str:>11} {gpu_preallocated_str:>15} {gpu_quota_str:>8} {gpu_status_bar:<29} | {last_updated_str:<25}"
             )
+    except StatsHTTPError as e:
+        logger.error(f"Failed to fetch stats: HTTP {e.status}")
+        sys.exit(1)
     except URLError as e:
         logger.error(f"Failed to contact slurm-quota service: {e}")
         sys.exit(1)

--- a/tests/functional/functional_base.py
+++ b/tests/functional/functional_base.py
@@ -6,7 +6,9 @@ import io
 import json
 import sys
 from contextlib import contextmanager, redirect_stdout
+from typing import Any, Dict, List, Optional
 from unittest.mock import patch
+from urllib.parse import parse_qs, unquote, urlparse
 
 from tests.test_support import SlurmQuotaTestCase
 
@@ -46,32 +48,103 @@ class FunctionalCLIBase(SlurmQuotaTestCase):
             yield buf
 
     @staticmethod
-    def stats_json_payload():
-        return {
-            "users": [
-                {
-                    "username": "alice",
-                    "job_count": 0,
-                    "last_updated": "2024-06-01T10:00:00",
-                    "total_consumed_cpu_minutes": 1,
-                    "total_preallocated_cpu_minutes": 0,
-                    "quota_cpu_minutes": -1,
-                    "total_consumed_gpu_minutes": 0,
-                    "total_preallocated_gpu_minutes": 0,
-                    "quota_gpu_minutes": -1,
-                }
-            ],
-            "accounts": [
-                {
-                    "account": "acct1",
-                    "job_count": 0,
-                    "last_updated": "2024-06-01T10:00:00",
-                    "total_consumed_cpu_minutes": 1,
-                    "total_preallocated_cpu_minutes": 0,
-                    "quota_cpu_minutes": -1,
-                    "total_consumed_gpu_minutes": 0,
-                    "total_preallocated_gpu_minutes": 0,
-                    "quota_gpu_minutes": -1,
-                }
-            ],
-        }
+    def stats_json_payload() -> Dict[str, List[Dict[str, Any]]]:
+        """Full multi-user / multi-account payload (no ``?username=`` filter)."""
+        return stats_payload_full()
+
+    @staticmethod
+    def stats_urlopen_side_effect(request: Any) -> FakeJsonUrlopenResponse:
+        """
+        Return JSON like the real ``/stats`` handler: full list without query param,
+        or users/accounts filtered from ``_STATS_REST_PAYLOAD`` when
+        ``?username=`` is present (mirrors association-based account filtering).
+        """
+        qs = parse_qs(urlparse(request.full_url).query)
+        raw = qs.get("username", [None])[0]
+        username: Optional[str] = unquote(raw) if raw else None
+        if username is None:
+            payload = _STATS_REST_PAYLOAD
+        else:
+            payload = _stats_payload_filtered_for_user(username)
+        return FakeJsonUrlopenResponse(payload)
+
+
+def _stats_user_row(
+    name: str,
+    consumed_cpu: int,
+    *,
+    job_count: int = 0,
+    prealloc_cpu: int = 0,
+    quota_cpu: int = -1,
+    consumed_gpu: int = 0,
+    prealloc_gpu: int = 0,
+    quota_gpu: int = -1,
+) -> Dict[str, Any]:
+    return {
+        "username": name,
+        "job_count": job_count,
+        "last_updated": "2024-06-01T10:00:00",
+        "total_consumed_cpu_minutes": consumed_cpu,
+        "total_preallocated_cpu_minutes": prealloc_cpu,
+        "quota_cpu_minutes": quota_cpu,
+        "total_consumed_gpu_minutes": consumed_gpu,
+        "total_preallocated_gpu_minutes": prealloc_gpu,
+        "quota_gpu_minutes": quota_gpu,
+    }
+
+
+def _stats_account_row(
+    name: str,
+    consumed_cpu: int,
+    *,
+    job_count: int = 0,
+    prealloc_cpu: int = 0,
+    quota_cpu: int = -1,
+    consumed_gpu: int = 0,
+    prealloc_gpu: int = 0,
+    quota_gpu: int = -1,
+) -> Dict[str, Any]:
+    return {
+        "account": name,
+        "job_count": job_count,
+        "last_updated": "2024-06-01T10:00:00",
+        "total_consumed_cpu_minutes": consumed_cpu,
+        "total_preallocated_cpu_minutes": prealloc_cpu,
+        "quota_cpu_minutes": quota_cpu,
+        "total_consumed_gpu_minutes": consumed_gpu,
+        "total_preallocated_gpu_minutes": prealloc_gpu,
+        "quota_gpu_minutes": quota_gpu,
+    }
+
+
+# Single canonical REST body for functional ``urlopen`` mocks (all users and accounts).
+_STATS_REST_PAYLOAD: Dict[str, List[Dict[str, Any]]] = {
+    "users": [
+        _stats_user_row("alice", 120, job_count=2, prealloc_cpu=60, quota_cpu=600),
+        _stats_user_row("bob", 30, job_count=1),
+    ],
+    "accounts": [
+        _stats_account_row("hpc", 100, job_count=3, quota_cpu=500),
+        _stats_account_row("dev", 40, job_count=0),
+    ],
+}
+
+# Which accounts appear when ``GET /stats?username=`` is set (like ``get_user_accounts``).
+_STATS_ACCOUNT_NAMES_BY_USER: Dict[str, frozenset[str]] = {
+    "alice": frozenset({"hpc"}),
+    "bob": frozenset({"dev"}),
+}
+
+
+def _stats_payload_filtered_for_user(username: str) -> Dict[str, List[Dict[str, Any]]]:
+    names = _STATS_ACCOUNT_NAMES_BY_USER.get(username)
+    if not names:
+        return {"users": [], "accounts": []}
+    users = [u for u in _STATS_REST_PAYLOAD["users"] if u["username"] == username]
+    accounts = [a for a in _STATS_REST_PAYLOAD["accounts"] if a["account"] in names]
+    return {"users": users, "accounts": accounts}
+
+
+def stats_payload_full() -> Dict[str, List[Dict[str, Any]]]:
+    """Return the shared multi-user / multi-account stats body (unfiltered)."""
+    return _STATS_REST_PAYLOAD

--- a/tests/functional/test_stats.py
+++ b/tests/functional/test_stats.py
@@ -2,28 +2,177 @@
 
 from __future__ import annotations
 
+from typing import Optional
 from unittest.mock import patch
 
-from tests.functional.functional_base import FunctionalCLIBase, FakeJsonUrlopenResponse
+from tests.functional.functional_base import FunctionalCLIBase
+from tests.testing_utils import dedent_lines
 
 
 class TestStatsCommand(FunctionalCLIBase):
-    def test_stats_variants_and_debug(self):
-        payload = self.stats_json_payload()
-        with patch.object(
-            self.sq, "urlopen", return_value=FakeJsonUrlopenResponse(payload)
-        ):
-            with patch.object(self.sq, "get_current_user", return_value="alice"):
-                with self.capture_stdout() as out:
-                    self.run_main(["slurm-quota", "stats"])
-                self.assertIn("alice", out.getvalue())
-
-            for argv in [
-                ["slurm-quota", "stats", "alice"],
-                ["slurm-quota", "stats", "--all"],
-                ["slurm-quota", "stats", "alice", "--all"],
-                ["slurm-quota", "--debug", "stats", "--all"],
-            ]:
+    def _run_stats(
+        self,
+        argv: list[str],
+        *,
+        expected: str,
+        current_user: Optional[str] = None,
+    ) -> None:
+        self.env({"NO_COLOR": "1"})
+        u = patch.object(
+            self.sq,
+            "urlopen",
+            side_effect=FunctionalCLIBase.stats_urlopen_side_effect,
+        )
+        t = patch.object(
+            self.sq, "format_timestamp_with_timezone", return_value="TS_FIXED"
+        )
+        if current_user is not None:
+            with (
+                u,
+                t,
+                patch.object(self.sq, "get_current_user", return_value=current_user),
+            ):
                 with self.capture_stdout() as out:
                     self.run_main(argv)
-                self.assertIn("alice", out.getvalue())
+        else:
+            with u, t:
+                with self.capture_stdout() as out:
+                    self.run_main(argv)
+        self.assertEqual(out.getvalue(), expected)
+
+    def test_stats_uses_current_user_when_username_omitted(self):
+        self._run_stats(
+            ["slurm-quota", "stats"],
+            current_user="alice",
+            expected=dedent_lines(
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "USER                      |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "alice                     |         120           60(2)      600 [██████░░░░░░░░░░░░░░]  30.0% |           0            0(2)        ∞                               | TS_FIXED                 ",
+                "",
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "ACCOUNT                   |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "hpc                       |         100            0(3)      500 [████░░░░░░░░░░░░░░░░]  20.0% |           0            0(3)        ∞                               | TS_FIXED                 ",
+            ),
+        )
+
+    def test_stats_with_explicit_username_alice(self):
+        self._run_stats(
+            ["slurm-quota", "stats", "alice"],
+            expected=dedent_lines(
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "USER                      |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "alice                     |         120           60(2)      600 [██████░░░░░░░░░░░░░░]  30.0% |           0            0(2)        ∞                               | TS_FIXED                 ",
+                "",
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "ACCOUNT                   |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "hpc                       |         100            0(3)      500 [████░░░░░░░░░░░░░░░░]  20.0% |           0            0(3)        ∞                               | TS_FIXED                 ",
+            ),
+        )
+
+    def test_stats_with_explicit_username_bob(self):
+        self._run_stats(
+            ["slurm-quota", "stats", "bob"],
+            expected=dedent_lines(
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "USER                      |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "bob                       |          30            0(1)        ∞                               |           0            0(1)        ∞                               | TS_FIXED                 ",
+                "",
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "ACCOUNT                   |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "dev                       |          40            0(0)        ∞                               |           0            0(0)        ∞                               | TS_FIXED                 ",
+            ),
+        )
+
+    def test_stats_with_all(self):
+        self._run_stats(
+            ["slurm-quota", "stats", "--all"],
+            expected=dedent_lines(
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "USER                      |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "alice                     |         120           60(2)      600 [██████░░░░░░░░░░░░░░]  30.0% |           0            0(2)        ∞                               | TS_FIXED                 ",
+                "bob                       |          30            0(1)        ∞                               |           0            0(1)        ∞                               | TS_FIXED                 ",
+                "",
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "ACCOUNT                   |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "hpc                       |         100            0(3)      500 [████░░░░░░░░░░░░░░░░]  20.0% |           0            0(3)        ∞                               | TS_FIXED                 ",
+                "dev                       |          40            0(0)        ∞                               |           0            0(0)        ∞                               | TS_FIXED                 ",
+            ),
+        )
+
+    def test_stats_with_username_and_all(self):
+        self._run_stats(
+            ["slurm-quota", "stats", "alice", "--all"],
+            expected=dedent_lines(
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "USER                      |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "alice                     |         120           60(2)      600 [██████░░░░░░░░░░░░░░]  30.0% |           0            0(2)        ∞                               | TS_FIXED                 ",
+                "bob                       |          30            0(1)        ∞                               |           0            0(1)        ∞                               | TS_FIXED                 ",
+                "",
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "ACCOUNT                   |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "hpc                       |         100            0(3)      500 [████░░░░░░░░░░░░░░░░]  20.0% |           0            0(3)        ∞                               | TS_FIXED                 ",
+                "dev                       |          40            0(0)        ∞                               |           0            0(0)        ∞                               | TS_FIXED                 ",
+            ),
+        )
+
+    def test_stats_with_debug_and_all(self):
+        self._run_stats(
+            ["slurm-quota", "--debug", "stats", "--all"],
+            expected=dedent_lines(
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "USER                      |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "alice                     |         120           60(2)      600 [██████░░░░░░░░░░░░░░]  30.0% |           0            0(2)        ∞                               | TS_FIXED                 ",
+                "bob                       |          30            0(1)        ∞                               |           0            0(1)        ∞                               | TS_FIXED                 ",
+                "",
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "ACCOUNT                   |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "hpc                       |         100            0(3)      500 [████░░░░░░░░░░░░░░░░]  20.0% |           0            0(3)        ∞                               | TS_FIXED                 ",
+                "dev                       |          40            0(0)        ∞                               |           0            0(0)        ∞                               | TS_FIXED                 ",
+            ),
+        )
+
+    def test_stats_with_alice_and_hours(self):
+        self._run_stats(
+            ["slurm-quota", "stats", "alice", "--hours"],
+            expected=dedent_lines(
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "USER                      |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "alice                     |        2.00         1.00(2)    10.00 [██████░░░░░░░░░░░░░░]  30.0% |        0.00         0.00(2)        ∞                               | TS_FIXED                 ",
+                "",
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "ACCOUNT                   |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "hpc                       |        1.67         0.00(3)     8.33 [████░░░░░░░░░░░░░░░░]  20.0% |        0.00         0.00(3)        ∞                               | TS_FIXED                 ",
+            ),
+        )
+
+    def test_stats_with_all_and_hours(self):
+        self._run_stats(
+            ["slurm-quota", "stats", "--all", "--hours"],
+            expected=dedent_lines(
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "USER                      |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "alice                     |        2.00         1.00(2)    10.00 [██████░░░░░░░░░░░░░░]  30.0% |        0.00         0.00(2)        ∞                               | TS_FIXED                 ",
+                "bob                       |        0.50         0.00(1)        ∞                               |        0.00         0.00(1)        ∞                               | TS_FIXED                 ",
+                "",
+                "                          |                                CPU                                 |                                GPU                                 |",
+                "ACCOUNT                   |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+                "hpc                       |        1.67         0.00(3)     8.33 [████░░░░░░░░░░░░░░░░]  20.0% |        0.00         0.00(3)        ∞                               | TS_FIXED                 ",
+                "dev                       |        0.67         0.00(0)        ∞                               |        0.00         0.00(0)        ∞                               | TS_FIXED                 ",
+            ),
+        )

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1,0 +1,15 @@
+"""Helpers shared by unit and functional tests."""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+
+def dedent_lines(*lines: str) -> str:
+    """
+    Build multiline text for stdout/assert comparisons.
+
+    Each logical line is prefixed with four spaces so ``textwrap.dedent`` can
+    remove a common margin while preserving table alignment in the source file.
+    """
+    return dedent("\n".join(f"    {line}" for line in lines) + "\n")

--- a/tests/unit/test_fetch_stats_from_service.py
+++ b/tests/unit/test_fetch_stats_from_service.py
@@ -1,0 +1,117 @@
+"""Unit tests for fetch_stats_from_service."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from urllib.error import URLError
+
+from tests.test_support import SlurmQuotaTestCase
+
+
+class _FakeUrlopenResponse:
+    def __init__(self, payload=None, status=200):
+        self.status = status
+        self._payload = payload if payload is not None else {}
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def _sample_payload():
+    return {
+        "users": [
+            {
+                "username": "alice",
+                "job_count": 2,
+                "last_updated": "2024-06-01T10:00:00",
+                "total_consumed_cpu_minutes": 120,
+                "total_preallocated_cpu_minutes": 60,
+                "quota_cpu_minutes": 600,
+                "total_consumed_gpu_minutes": 0,
+                "total_preallocated_gpu_minutes": 0,
+                "quota_gpu_minutes": -1,
+            }
+        ],
+        "accounts": [
+            {
+                "account": "acct1",
+                "job_count": 0,
+                "last_updated": None,
+                "total_consumed_cpu_minutes": 1,
+                "total_preallocated_cpu_minutes": 0,
+                "quota_cpu_minutes": -1,
+                "total_consumed_gpu_minutes": 0,
+                "total_preallocated_gpu_minutes": 0,
+                "quota_gpu_minutes": -1,
+            }
+        ],
+    }
+
+
+class TestFetchStatsFromService(SlurmQuotaTestCase):
+    def test_returns_users_and_accounts(self):
+        payload = _sample_payload()
+        with patch.object(
+            self.sq, "urlopen", return_value=_FakeUrlopenResponse(payload)
+        ):
+            users, accounts = self.sq.fetch_stats_from_service("alice", False)
+        self.assertEqual(len(users), 1)
+        self.assertEqual(users[0]["username"], "alice")
+        self.assertEqual(len(accounts), 1)
+        self.assertEqual(accounts[0]["account"], "acct1")
+
+    def test_empty_payload_lists_when_keys_missing(self):
+        with patch.object(self.sq, "urlopen", return_value=_FakeUrlopenResponse({})):
+            users, accounts = self.sq.fetch_stats_from_service(None, True)
+        self.assertEqual(users, [])
+        self.assertEqual(accounts, [])
+
+    def test_adds_username_query_when_filtered(self):
+        with patch.object(
+            self.sq, "urlopen", return_value=_FakeUrlopenResponse(_sample_payload())
+        ) as m_urlopen:
+            self.sq.fetch_stats_from_service("alice", False)
+        req = m_urlopen.call_args[0][0]
+        self.assertIn("username=alice", req.full_url)
+
+    def test_no_username_query_when_show_all(self):
+        with patch.object(
+            self.sq, "urlopen", return_value=_FakeUrlopenResponse(_sample_payload())
+        ) as m_urlopen:
+            self.sq.fetch_stats_from_service("alice", True)
+        req = m_urlopen.call_args[0][0]
+        self.assertNotIn("username=", req.full_url)
+
+    def test_respects_slurm_quota_url(self):
+        self.env({"SLURM_QUOTA_URL": "http://custom.example:9999/api/"})
+        with patch.object(
+            self.sq, "urlopen", return_value=_FakeUrlopenResponse(_sample_payload())
+        ) as m_urlopen:
+            self.sq.fetch_stats_from_service(None, True)
+        req = m_urlopen.call_args[0][0]
+        self.assertTrue(
+            req.full_url.startswith("http://custom.example:9999/api/"),
+            req.full_url,
+        )
+        self.assertIn("/stats", req.full_url)
+
+    def test_raises_stats_http_error_on_bad_status(self):
+        with patch.object(
+            self.sq, "urlopen", return_value=_FakeUrlopenResponse({}, status=500)
+        ):
+            with self.assertRaises(self.sq.StatsHTTPError) as cm:
+                self.sq.fetch_stats_from_service(None, True)
+        self.assertEqual(cm.exception.status, 500)
+
+    def test_urlerror_propagates(self):
+        with patch.object(self.sq, "urlopen", side_effect=URLError("boom")):
+            with self.assertRaises(URLError):
+                self.sq.fetch_stats_from_service(None, True)

--- a/tests/unit/test_show_user_stats.py
+++ b/tests/unit/test_show_user_stats.py
@@ -1,0 +1,225 @@
+"""Unit tests for show_user_stats."""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from urllib.error import URLError
+
+from tests.test_support import SlurmQuotaTestCase
+from tests.testing_utils import dedent_lines
+
+
+def _sample_users_and_accounts():
+    users = [
+        {
+            "username": "alice",
+            "job_count": 2,
+            "last_updated": "2024-06-01T10:00:00",
+            "total_consumed_cpu_minutes": 120,
+            "total_preallocated_cpu_minutes": 60,
+            "quota_cpu_minutes": 600,
+            "total_consumed_gpu_minutes": 0,
+            "total_preallocated_gpu_minutes": 0,
+            "quota_gpu_minutes": -1,
+        }
+    ]
+    accounts = [
+        {
+            "account": "acct1",
+            "job_count": 0,
+            "last_updated": None,
+            "total_consumed_cpu_minutes": 1,
+            "total_preallocated_cpu_minutes": 0,
+            "quota_cpu_minutes": -1,
+            "total_consumed_gpu_minutes": 0,
+            "total_preallocated_gpu_minutes": 0,
+            "quota_gpu_minutes": -1,
+        }
+    ]
+    return users, accounts
+
+
+class TestShowUserStats(SlurmQuotaTestCase):
+    def _run_show(self, *args, **kwargs):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.sq.show_user_stats(*args, **kwargs)
+        return buf.getvalue()
+
+    def test_no_data_for_explicit_username(self):
+        with patch.object(
+            self.sq,
+            "fetch_stats_from_service",
+            return_value=([], []),
+        ):
+            out = self._run_show("bob", False)
+        expected = dedent_lines("No data found for user: bob")
+        self.assertEqual(out, expected)
+
+    def test_no_users_when_show_all_empty(self):
+        with patch.object(
+            self.sq,
+            "fetch_stats_from_service",
+            return_value=([], []),
+        ):
+            out = self._run_show(None, True)
+        expected = dedent_lines("No users found in service")
+        self.assertEqual(out, expected)
+
+    def test_prints_user_and_account_tables(self):
+        self.env({"NO_COLOR": "1"})
+        users, accounts = _sample_users_and_accounts()
+        with (
+            patch.object(
+                self.sq,
+                "fetch_stats_from_service",
+                return_value=(users, accounts),
+            ),
+            patch.object(
+                self.sq,
+                "format_timestamp_with_timezone",
+                return_value="TS_FIXED",
+            ),
+        ):
+            out = self._run_show("alice", False)
+        expected = dedent_lines(
+            "                          |                                CPU                                 |                                GPU                                 |",
+            "USER                      |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+            "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+            "alice                     |         120           60(2)      600 [██████░░░░░░░░░░░░░░]  30.0% |           0            0(2)        ∞                               | TS_FIXED                 ",
+            "",
+            "                          |                                CPU                                 |                                GPU                                 |",
+            "ACCOUNT                   |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+            "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+            "acct1                     |           1            0(0)        ∞                               |           0            0(0)        ∞                               | TS_FIXED                 ",
+        )
+        self.assertEqual(out, expected)
+
+    def test_display_hours_formats_numbers(self):
+        self.env({"NO_COLOR": "1"})
+        user = {
+            "username": "u1",
+            "job_count": 0,
+            "last_updated": None,
+            "total_consumed_cpu_minutes": 120,
+            "total_preallocated_cpu_minutes": 0,
+            "quota_cpu_minutes": -1,
+            "total_consumed_gpu_minutes": 0,
+            "total_preallocated_gpu_minutes": 0,
+            "quota_gpu_minutes": -1,
+        }
+        with (
+            patch.object(
+                self.sq,
+                "fetch_stats_from_service",
+                return_value=([user], []),
+            ),
+            patch.object(
+                self.sq,
+                "format_timestamp_with_timezone",
+                return_value="TS_FIXED",
+            ),
+        ):
+            out = self._run_show("u1", False, display_hours=True)
+        expected = dedent_lines(
+            "                          |                                CPU                                 |                                GPU                                 |",
+            "USER                      |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+            "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+            "u1                        |        2.00         0.00(0)        ∞                               |        0.00         0.00(0)        ∞                               | TS_FIXED                 ",
+            "",
+            "                          |                                CPU                                 |                                GPU                                 |",
+            "ACCOUNT                   |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+            "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+        )
+        self.assertEqual(out, expected)
+
+    def test_finite_quota_shows_status_bar(self):
+        self.env({"NO_COLOR": "1"})
+        user = {
+            "username": "u1",
+            "job_count": 0,
+            "last_updated": None,
+            "total_consumed_cpu_minutes": 50,
+            "total_preallocated_cpu_minutes": 0,
+            "quota_cpu_minutes": 100,
+            "total_consumed_gpu_minutes": 0,
+            "total_preallocated_gpu_minutes": 0,
+            "quota_gpu_minutes": -1,
+        }
+        with (
+            patch.object(
+                self.sq,
+                "fetch_stats_from_service",
+                return_value=([user], []),
+            ),
+            patch.object(
+                self.sq,
+                "format_timestamp_with_timezone",
+                return_value="TS_FIXED",
+            ),
+        ):
+            out = self._run_show("u1", False)
+        expected = dedent_lines(
+            "                          |                                CPU                                 |                                GPU                                 |",
+            "USER                      |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+            "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+            "u1                        |          50            0(0)      100 [██████████░░░░░░░░░░]  50.0% |           0            0(0)        ∞                               | TS_FIXED                 ",
+            "",
+            "                          |                                CPU                                 |                                GPU                                 |",
+            "ACCOUNT                   |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        |    CONSUMED  PREALLOC(JOBS)    QUOTA STATUS                        | LAST UPDATED             ",
+            "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
+        )
+        self.assertEqual(out, expected)
+
+    def test_uses_get_current_user_when_username_omitted(self):
+        with (
+            patch.object(self.sq, "get_current_user", return_value="carol") as m_gc,
+            patch.object(
+                self.sq,
+                "fetch_stats_from_service",
+                return_value=([], []),
+            ) as m_fetch,
+        ):
+            out = self._run_show(None, False)
+        m_gc.assert_called_once()
+        m_fetch.assert_called_once_with("carol", False)
+        self.assertEqual(out, dedent_lines("No users found in service"))
+
+    def test_get_current_user_keyerror_exits(self):
+        with patch.object(self.sq, "get_current_user", side_effect=KeyError):
+            with self.assertRaises(SystemExit) as cm:
+                self.sq.show_user_stats(None, False)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_stats_http_error_exits(self):
+        with patch.object(
+            self.sq,
+            "fetch_stats_from_service",
+            side_effect=self.sq.StatsHTTPError(502),
+        ):
+            with self.assertRaises(SystemExit) as cm:
+                self.sq.show_user_stats("x", False)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_urlerror_exits(self):
+        with patch.object(
+            self.sq,
+            "fetch_stats_from_service",
+            side_effect=URLError("down"),
+        ):
+            with self.assertRaises(SystemExit) as cm:
+                self.sq.show_user_stats("x", False)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_generic_exception_exits(self):
+        with patch.object(
+            self.sq,
+            "fetch_stats_from_service",
+            side_effect=ValueError("bad json"),
+        ):
+            with self.assertRaises(SystemExit) as cm:
+                self.sq.show_user_stats("x", False)
+        self.assertEqual(cm.exception.code, 1)


### PR DESCRIPTION
Instead of display quotas and consumtions in minutes, they are displayed in hours with this option.

fix #3