### PR TITLE
Add --quiet option on slurm-quota command

### DIFF
--- a/man/slurm-quota.1.adoc
+++ b/man/slurm-quota.1.adoc
@@ -11,7 +11,7 @@ slurm-quota - manage Slurm CPU/GPU quota accounting, limits, and stats
 
 == Synopsis
 
-*slurm-quota* [*-h*] [*--debug*] [*--version*] <command> [<args>...]
+*slurm-quota* [*-h*] [*--debug* | *-q* | *--quiet*] [*--version*] <command> [<args>...]
 
 == Description
 
@@ -27,7 +27,10 @@ The database path is fixed to `/var/lib/state/slurm-quota/slurm-quota.db`.
   Show help and exit.
 
 *--debug*::
-  Enable debug logging.
+  Enable debug output.
+
+*-q*, *--quiet*::
+  Only print errors and warnings.
 
 *--version*::
   Show program version and exit.

--- a/slurm-quota
+++ b/slurm-quota
@@ -56,20 +56,27 @@ DEFAULT_QUOTA_SETTINGS = {
 
 
 # Configure logging
-def setup_logging(debug: bool = False) -> None:
+def setup_logging(debug: bool = False, quiet: bool = False) -> None:
     """
     Setup logging configuration.
 
     Args:
-        debug: If True, set logging level to DEBUG, otherwise INFO
+        debug: If True, set logging level to DEBUG
+        quiet: If True, set logging level to WARNING
     """
-    level = logging.DEBUG if debug else logging.INFO
+    if debug:
+        level = logging.DEBUG
+    elif quiet:
+        level = logging.WARNING
+    else:
+        level = logging.INFO
     logging.basicConfig(
         level=level,
         format="%(asctime)s - %(levelname)s - %(message)s",
         handlers=[
             logging.StreamHandler(sys.stderr),
         ],
+        force=True,
     )
 
 
@@ -2146,11 +2153,18 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
-    # Add global debug option
-    parser.add_argument(
+    # Add global logging options
+    log_level_group = parser.add_mutually_exclusive_group()
+    log_level_group.add_argument(
         "--debug",
         action="store_true",
-        help="Enable debug logging",
+        help="Print debug output",
+    )
+    log_level_group.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Only print errors and warnings",
     )
     parser.add_argument(
         "--version",
@@ -2367,8 +2381,8 @@ def main():
 
     args = parser.parse_args()
 
-    # Setup logging with debug level if requested
-    setup_logging(debug=args.debug)
+    # Setup logging with selected log verbosity
+    setup_logging(debug=args.debug, quiet=args.quiet)
 
     if args.command == "charge":
         charge_command()

--- a/slurm-quota.bash-completion
+++ b/slurm-quota.bash-completion
@@ -88,7 +88,7 @@ _slurm_quota() {
             (( i++ ))
             continue
         fi
-        if [[ "${words[i]}" == --debug || "${words[i]}" == --version || "${words[i]}" == -h || "${words[i]}" == --help ]]; then
+        if [[ "${words[i]}" == --debug || "${words[i]}" == -q || "${words[i]}" == --quiet || "${words[i]}" == --version || "${words[i]}" == -h || "${words[i]}" == --help ]]; then
             continue
         fi
         if [[ "${words[i]}" != -* ]]; then
@@ -99,7 +99,7 @@ _slurm_quota() {
     done
 
     if [[ -z "$subcmd" ]]; then
-        COMPREPLY=($(compgen -W "--debug --version -h --help ${subcommands[*]}" -- "$cur"))
+        COMPREPLY=($(compgen -W "--debug -q --quiet --version -h --help ${subcommands[*]}" -- "$cur"))
         return 0
     fi
 

--- a/tests/functional/test_main.py
+++ b/tests/functional/test_main.py
@@ -15,3 +15,6 @@ class TestMain(FunctionalCLIBase):
         self.assertEqual(
             stdout.getvalue().strip(), f"slurm-quota {self.sq.APP_VERSION}"
         )
+
+    def test_global_debug_and_quiet_are_mutually_exclusive(self):
+        self.run_main_exit(["slurm-quota", "--debug", "--quiet", "prune"], 2)


### PR DESCRIPTION
This raises log level to warning instead of informational by default.

fix #35