### PR TITLE
Add --user and --account option on prune command

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,8 @@ sudo slurm-quota set-gpu-factor default 1.0  # Default factor (used if type is n
   - `--users`: remove users with both consumed CPU and consumed GPU at 0
   - `--accounts`: remove accounts with both consumed CPU and consumed GPU at 0
   - `--all`: prune all categories above (default behavior when no selector is provided)
+  - `--user <username>`: limit user pruning candidates to one username
+  - `--account <account>`: limit account pruning candidates to one account
   - `--dry-run`: report how many preallocations/users/accounts would be removed, without deleting rows
 
 Example:
@@ -561,7 +563,9 @@ Example:
 sudo slurm-quota prune                  # default: same as --all
 sudo slurm-quota prune --preallocs      # prune only orphaned preallocations
 sudo slurm-quota prune --users          # prune only users with 0 consumed CPU/GPU
+sudo slurm-quota prune --users --user alice      # prune only this eligible user
 sudo slurm-quota prune --accounts       # prune only accounts with 0 consumed CPU/GPU
+sudo slurm-quota prune --accounts --account hpc  # prune only this eligible account
 sudo slurm-quota prune --dry-run        # preview removals without applying them
 ```
 

--- a/man/slurm-quota.1.adoc
+++ b/man/slurm-quota.1.adoc
@@ -216,7 +216,7 @@ sudo slurm-quota set-default-quotas --user-cpu 50000 --account-cpu 200000
 
 === prune
 
-*slurm-quota prune* [*--preallocs* | *--users* | *--accounts* | *--all*] [*--dry-run*]
+*slurm-quota prune* [*--preallocs* | *--users* | *--accounts* | *--all*] [*--user* <username>] [*--account* <account>] [*--dry-run*]
 
 Prune orphaned/unused records from the database.
 This command must run as `root`.
@@ -238,6 +238,12 @@ Selectors (mutually exclusive):
 *--dry-run*::
   Report what would be removed, without deleting anything.
 
+*--user* <username>::
+  Limit user pruning candidates to this username (applies when users are in selected targets).
+
+*--account* <account>::
+  Limit account pruning candidates to this account (applies when accounts are in selected targets).
+
 Examples:
 
 ....
@@ -245,7 +251,9 @@ sudo slurm-quota prune
 sudo slurm-quota prune --dry-run
 sudo slurm-quota prune --preallocs
 sudo slurm-quota prune --users
+sudo slurm-quota prune --users --user alice
 sudo slurm-quota prune --accounts
+sudo slurm-quota prune --accounts --account hpc
 sudo slurm-quota prune --all
 ....
 

--- a/slurm-quota
+++ b/slurm-quota
@@ -627,13 +627,20 @@ def collect_active_job_uuids() -> set[str]:
     return uuids
 
 
-def prune_resources(targets: set[str], dry_run: bool = False) -> Dict[str, int]:
+def prune_resources(
+    targets: set[str],
+    dry_run: bool = False,
+    user_filter: Optional[str] = None,
+    account_filter: Optional[str] = None,
+) -> Dict[str, int]:
     """
     Prune selected resource records from the database.
 
     Args:
         targets: Set of prune targets among {"preallocs", "users", "accounts"}.
         dry_run: If True, report counts without deleting rows.
+        user_filter: Optional username to limit user pruning candidates.
+        account_filter: Optional account to limit account pruning candidates.
 
     Returns:
         Mapping with deleted (or deletable in dry-run) rows per target.
@@ -664,14 +671,17 @@ def prune_resources(targets: set[str], dry_run: bool = False) -> Dict[str, int]:
 
         users_to_delete: List[str] = []
         if "users" in targets:
-            cursor.execute(
-                """
+            users_query = """
                 SELECT username
                 FROM users
                 WHERE total_consumed_cpu_minutes = 0
                   AND total_consumed_gpu_minutes = 0
-                """
-            )
+            """
+            users_params: List[str] = []
+            if user_filter:
+                users_query += " AND username = ?"
+                users_params.append(user_filter)
+            cursor.execute(users_query, users_params)
             users_to_delete = [
                 str(username) for (username,) in cursor.fetchall() if username
             ]
@@ -681,14 +691,17 @@ def prune_resources(targets: set[str], dry_run: bool = False) -> Dict[str, int]:
 
         accounts_to_delete: List[str] = []
         if "accounts" in targets:
-            cursor.execute(
-                """
+            accounts_query = """
                 SELECT account
                 FROM accounts
                 WHERE total_consumed_cpu_minutes = 0
                   AND total_consumed_gpu_minutes = 0
-                """
-            )
+            """
+            accounts_params: List[str] = []
+            if account_filter:
+                accounts_query += " AND account = ?"
+                accounts_params.append(account_filter)
+            cursor.execute(accounts_query, accounts_params)
             accounts_to_delete = [
                 str(account) for (account,) in cursor.fetchall() if account
             ]
@@ -2093,6 +2106,8 @@ def prune_command(
     accounts: bool = False,
     all_targets: bool = False,
     dry_run: bool = False,
+    user_filter: Optional[str] = None,
+    account_filter: Optional[str] = None,
 ) -> None:
     """
     Execute the prune command to remove selected orphan/unused entries.
@@ -2116,7 +2131,12 @@ def prune_command(
                 targets.add("users")
             if accounts:
                 targets.add("accounts")
-        counts = prune_resources(targets, dry_run=dry_run)
+        counts = prune_resources(
+            targets,
+            dry_run=dry_run,
+            user_filter=user_filter,
+            account_filter=account_filter,
+        )
         selected_counts = {target: counts[target] for target in sorted(targets)}
 
         if dry_run:
@@ -2355,6 +2375,14 @@ def main():
         action="store_true",
         help="Show how many entries would be removed without deleting anything",
     )
+    prune_parser.add_argument(
+        "--user",
+        help="Limit users pruning to a specific username",
+    )
+    prune_parser.add_argument(
+        "--account",
+        help="Limit accounts pruning to a specific account",
+    )
 
     # Serve command (HTTP JSON API for stats, designed for systemd socket activation)
     serve_parser = subparsers.add_parser(
@@ -2427,6 +2455,8 @@ def main():
             accounts=args.accounts,
             all_targets=args.all,
             dry_run=args.dry_run,
+            user_filter=args.user,
+            account_filter=args.account,
         )
     elif args.command == "serve":
         run_serve_command(args.host, args.port, args.idle_timeout)

--- a/slurm-quota.bash-completion
+++ b/slurm-quota.bash-completion
@@ -157,7 +157,7 @@ _slurm_quota() {
             COMPREPLY=($(compgen -W "$base_opts --user-cpu --user-gpu --account-cpu --account-gpu" -- "$cur"))
             ;;
         prune)
-            COMPREPLY=($(compgen -W "$base_opts --preallocs --users --accounts --all --dry-run" -- "$cur"))
+            COMPREPLY=($(compgen -W "$base_opts --preallocs --users --accounts --all --dry-run --user --account" -- "$cur"))
             ;;
         serve)
             COMPREPLY=($(compgen -W "$base_opts --host --port --idle-timeout" -- "$cur"))

--- a/tests/functional/test_prune.py
+++ b/tests/functional/test_prune.py
@@ -410,6 +410,216 @@ class TestPruneCommand(FunctionalCLIBase):
                 1,
             )
 
+    def test_prune_users_filtered_by_username(self):
+        self.init_db()
+        with self.db_connection() as conn:
+            conn.executemany(
+                """
+                INSERT INTO users (
+                    username, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                [("u_keep", 0, 0), ("u_drop", 0, 0), ("u_busy", 5, 0)],
+            )
+            conn.execute(
+                """
+                INSERT INTO accounts (
+                    account, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                ("a1", 0, 0),
+            )
+            conn.commit()
+
+        with patch.object(self.sq, "get_current_user", return_value="root"):
+            with self.capture_stdout() as out:
+                self.run_main(["slurm-quota", "prune", "--users", "--user", "u_drop"])
+        self.assertEqual(
+            out.getvalue(),
+            "Removed 0 orphan preallocation(s), 1 user(s), 0 account(s)\n",
+        )
+        with self.db_connection() as conn:
+            users = {
+                row[0]
+                for row in conn.execute("SELECT username FROM users ORDER BY username")
+            }
+            self.assertEqual(users, {"u_busy", "u_keep"})
+
+    def test_prune_users_filtered_username_ineligible(self):
+        self.init_db()
+        with self.db_connection() as conn:
+            conn.executemany(
+                """
+                INSERT INTO users (
+                    username, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                [("u_zero", 0, 0), ("u_busy", 5, 0)],
+            )
+            conn.commit()
+
+        with patch.object(self.sq, "get_current_user", return_value="root"):
+            with self.capture_stdout() as out:
+                self.run_main(["slurm-quota", "prune", "--users", "--user", "u_busy"])
+        self.assertEqual(out.getvalue(), "Nothing to prune\n")
+        with self.db_connection() as conn:
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM users").fetchone()[0], 2
+            )
+
+    def test_prune_accounts_filtered_by_account(self):
+        self.init_db()
+        with self.db_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO users (
+                    username, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                ("u1", 0, 0),
+            )
+            conn.executemany(
+                """
+                INSERT INTO accounts (
+                    account, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                [("a_keep", 0, 0), ("a_drop", 0, 0), ("a_busy", 0, 9)],
+            )
+            conn.commit()
+
+        with patch.object(self.sq, "get_current_user", return_value="root"):
+            with self.capture_stdout() as out:
+                self.run_main(
+                    ["slurm-quota", "prune", "--accounts", "--account", "a_drop"]
+                )
+        self.assertEqual(
+            out.getvalue(),
+            "Removed 0 orphan preallocation(s), 0 user(s), 1 account(s)\n",
+        )
+        with self.db_connection() as conn:
+            accounts = {
+                row[0]
+                for row in conn.execute("SELECT account FROM accounts ORDER BY account")
+            }
+            self.assertEqual(accounts, {"a_busy", "a_keep"})
+
+    def test_prune_accounts_filtered_dry_run(self):
+        self.init_db()
+        with self.db_connection() as conn:
+            conn.executemany(
+                """
+                INSERT INTO users (
+                    username, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                [("u1", 0, 0), ("u2", 0, 0)],
+            )
+            conn.executemany(
+                """
+                INSERT INTO accounts (
+                    account, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                [("a1", 0, 0), ("a2", 0, 0)],
+            )
+            conn.commit()
+
+        with patch.object(self.sq, "get_current_user", return_value="root"):
+            with self.capture_stdout() as out:
+                self.run_main(
+                    [
+                        "slurm-quota",
+                        "prune",
+                        "--accounts",
+                        "--account",
+                        "a1",
+                        "--dry-run",
+                    ]
+                )
+        self.assertEqual(
+            out.getvalue(),
+            "Dry-run: would remove 0 orphan preallocation(s), 0 user(s), 1 account(s)\n",
+        )
+        with self.db_connection() as conn:
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM accounts").fetchone()[0], 2
+            )
+
+    def test_prune_accounts_filtered_account_ineligible(self):
+        self.init_db()
+        with self.db_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO users (
+                    username, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                ("u1", 0, 0),
+            )
+            conn.executemany(
+                """
+                INSERT INTO accounts (
+                    account, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                [("a_zero", 0, 0), ("a_busy", 2, 0)],
+            )
+            conn.commit()
+
+        with patch.object(self.sq, "get_current_user", return_value="root"):
+            with self.capture_stdout() as out:
+                self.run_main(
+                    ["slurm-quota", "prune", "--accounts", "--account", "a_busy"]
+                )
+        self.assertEqual(out.getvalue(), "Nothing to prune\n")
+        with self.db_connection() as conn:
+            accounts = {
+                row[0]
+                for row in conn.execute("SELECT account FROM accounts ORDER BY account")
+            }
+            self.assertEqual(accounts, {"a_busy", "a_zero"})
+
+    def test_prune_user_filter_does_not_allow_sql_injection(self):
+        self.init_db()
+        with self.db_connection() as conn:
+            conn.executemany(
+                """
+                INSERT INTO users (
+                    username, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                [("u1", 0, 0), ("u2", 0, 0)],
+            )
+            conn.execute(
+                """
+                INSERT INTO accounts (
+                    account, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                ("a1", 0, 0),
+            )
+            conn.commit()
+
+        with patch.object(self.sq, "get_current_user", return_value="root"):
+            with self.capture_stdout() as out:
+                self.run_main(
+                    [
+                        "slurm-quota",
+                        "prune",
+                        "--users",
+                        "--user",
+                        "u1' OR 1=1 --",
+                    ]
+                )
+        self.assertEqual(out.getvalue(), "Nothing to prune\n")
+        with self.db_connection() as conn:
+            users = {
+                row[0]
+                for row in conn.execute("SELECT username FROM users ORDER BY username")
+            }
+            self.assertEqual(users, {"u1", "u2"})
+
     def test_prune_prints_nothing_to_prune(self):
         self.init_db()
         with self.db_connection() as conn:

--- a/tests/unit/test_prune_resources.py
+++ b/tests/unit/test_prune_resources.py
@@ -184,3 +184,91 @@ class TestPruneResources(SlurmQuotaTestCase):
             self.assertEqual(
                 conn.execute("SELECT COUNT(*) FROM accounts").fetchone()[0], 0
             )
+
+    def test_prune_resources_applies_user_and_account_filters(self):
+        self.init_db()
+        with self.db_connection() as conn:
+            conn.executemany(
+                """
+                INSERT INTO users (
+                    username, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                [("u1", 0, 0), ("u2", 0, 0), ("u_busy", 1, 0)],
+            )
+            conn.executemany(
+                """
+                INSERT INTO accounts (
+                    account, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                [("a1", 0, 0), ("a2", 0, 0), ("a_busy", 0, 1)],
+            )
+            conn.commit()
+
+        with self.assertLogs("slurm_quota", level="INFO") as log_cm:
+            counts = self.sq.prune_resources(
+                {"users", "accounts"},
+                dry_run=True,
+                user_filter="u1",
+                account_filter="a2",
+            )
+
+        self.assertEqual(counts, {"preallocs": 0, "users": 1, "accounts": 1})
+        self.assertIn(
+            "INFO:slurm_quota:Eligible user for pruning: u1",
+            log_cm.output,
+        )
+        self.assertNotIn(
+            "INFO:slurm_quota:Eligible user for pruning: u2",
+            log_cm.output,
+        )
+        self.assertIn(
+            "INFO:slurm_quota:Eligible account for pruning: a2",
+            log_cm.output,
+        )
+        self.assertNotIn(
+            "INFO:slurm_quota:Eligible account for pruning: a1",
+            log_cm.output,
+        )
+
+    def test_prune_resources_filtered_non_eligible_user_and_account(self):
+        self.init_db()
+        with self.db_connection() as conn:
+            conn.executemany(
+                """
+                INSERT INTO users (
+                    username, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                [("u_busy", 3, 0), ("u_zero", 0, 0)],
+            )
+            conn.executemany(
+                """
+                INSERT INTO accounts (
+                    account, total_consumed_cpu_minutes, total_consumed_gpu_minutes
+                ) VALUES (?, ?, ?)
+                """,
+                [("a_busy", 0, 4), ("a_zero", 0, 0)],
+            )
+            conn.commit()
+
+        counts = self.sq.prune_resources(
+            {"users", "accounts"},
+            dry_run=False,
+            user_filter="u_busy",
+            account_filter="a_busy",
+        )
+        self.assertEqual(counts, {"preallocs": 0, "users": 0, "accounts": 0})
+
+        with self.db_connection() as conn:
+            users = {
+                row[0]
+                for row in conn.execute("SELECT username FROM users ORDER BY username")
+            }
+            accounts = {
+                row[0]
+                for row in conn.execute("SELECT account FROM accounts ORDER BY account")
+            }
+            self.assertEqual(users, {"u_busy", "u_zero"})
+            self.assertEqual(accounts, {"a_busy", "a_zero"})


### PR DESCRIPTION
Add --user and --account option on prune command to provide ability to
filter by name of user or account eligible for pruning.

fix https://github.com/rackslab/slurm-quota/issues/33