### PR TITLE
Dedicated slurm-quota-{charge,serve} commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The solution is built around a SQLite database located at `/var/lib/state/slurm-
 This database is used by 2 programs:
 
 - `job_submit.lua`, a Lua script designed to be used as a Slurm submission plugin.
-- `slurm-quota`, a Python application with several subcommands intended to be executed by Slurm, administrators, and cluster users.
+- `slurm-quota`, a Python application with several commands intended to be executed by Slurm, administrators, and cluster users.
 
 When the Lua submission plugin is enabled in the Slurm configuration, the `job_submit.lua` script is automatically called during each job submission or modification (`sbatch`, `srun`, `scontrol`, etc.) to validate the request before it is accepted into the system. The script can thus apply custom rules (such as quota control for example) and reject jobs that do not comply with the defined policies.
 
@@ -25,12 +25,12 @@ When a job submission is accepted, the Lua script creates a corresponding preall
 
 The Lua script generates a UUID at submission time to uniquely identify jobs and to be able to track the preallocated time until their completion. The job ID unfortunately cannot be used for this purpose because it is not yet available at the time of the `job_submit` callback (Slurm assigns a job ID later only if the job is accepted by the `job_submit.lua` script). The generated UUID identifier is stored in the job's `admin_comment` field, so it can be retrieved by the solution to reassociate the preallocation with the job during other steps.
 
-The `slurm-quota-charge-wrapper` wrapper script is designed to be executed by Slurm's job completion _script_ plugin (`JobCompType=script`). When this functionality is enabled, Slurm executes this script every time a job completes or is cancelled. This wrapper script actually executes the `slurm-quota charge` command. The wrapper is used for 2 reasons:
+The `slurm-quota-charge-wrapper` wrapper script is designed to be executed by Slurm's job completion _script_ plugin (`JobCompType=script`). When this functionality is enabled, Slurm executes this script every time a job completes or is cancelled. This wrapper script actually executes the `slurm-quota-charge` command. The wrapper is used for 2 reasons:
 
 - Slurm does not allow directly specifying arguments to the command executed by the _script_ completion plugin. The wrapper allows this limitation to be bypassed.
-- Slurm systematically redirects JobComp script output to `/dev/null`. By using the wrapper as an intermediate layer, it is possible to redirect the output of the `slurm-quota charge` command to a dedicated log file (`/var/log/slurm/charge/slurm-quota-charge.log`) to ensure that all processing information and any errors are preserved to trace operations.
+- Slurm systematically redirects JobComp script output to `/dev/null`. By using the wrapper as an intermediate layer, it is possible to redirect the output of the `slurm-quota-charge` command to a dedicated log file (`/var/log/slurm/charge/slurm-quota-charge.log`) to ensure that all processing information and any errors are preserved to trace operations.
 
-Upon job completion, the `slurm-quota charge` command retrieves the UUID from `admin_comment` and the allocated GPU resources from `AllocTRES` (via `sacct`). It calculates the effective consumption in CPU minutes according to `PROCS × (END − START) / 60` and in GPU minutes according to the allocated GPUs, their type, and the configured load factors. It credits these consumptions to the user and to the account, and deletes the corresponding preallocation in the database. This step ensures that the difference between "reserved" and "actually used" is correctly reconciled for both dimensions (CPU and GPU).
+Upon job completion, the `slurm-quota-charge` command retrieves the UUID from `admin_comment` and the allocated GPU resources from `AllocTRES` (via `sacct`). It calculates the effective consumption in CPU minutes according to `PROCS × (END − START) / 60` and in GPU minutes according to the allocated GPUs, their type, and the configured load factors. It credits these consumptions to the user and to the account, and deletes the corresponding preallocation in the database. This step ensures that the difference between "reserved" and "actually used" is correctly reconciled for both dimensions (CPU and GPU).
 
 In the SQLite database, there are 4 tables:
 
@@ -41,7 +41,7 @@ In the SQLite database, there are 4 tables:
 
 We record the amount of preallocated time per job rather than a global value per user to allow fine-grained updates during modifications (increase or decrease of `time_limit`/`num_tasks`), targeted deletion of the preallocation upon completion, and robust cleanup of orphans. A global value would hide the detail per job and significantly complicate adjustments and cancellations, with an increased risk of inconsistencies.
 
-The SQLite database file must have the system user `slurm` as owner, with mode `0644` to restrict modification permission to the `slurm` user (used by `slurmctld` for the Lua script and the jobcomp script) and to administrators with the `root` account. Other users only have read-only access to the database. The `slurm-quota` script automatically creates the database with the `charge`, `user-quota`, and `account-quota` commands (intended for Slurm and administrators), setting the correct permissions on the file.
+The SQLite database file must have the system user `slurm` as owner, with mode `0644` to restrict modification permission to the `slurm` user (used by `slurmctld` for the Lua script and the jobcomp script) and to administrators with the `root` account. Other users only have read-only access to the database. The `slurm-quota` script and `slurm-quota-charge` automatically create the database with the `user-quota` and `account-quota` commands (intended for Slurm and administrators), setting the correct permissions on the file.
 
 The commands `slurm-quota user-quota`, `slurm-quota account-quota`, `slurm-quota user-gpu-quota`, and `slurm-quota account-gpu-quota` respectively allow assigning CPU and GPU quotas to users and accounts.
 The `slurm-quota adjust` command (restricted to root) allows manually adjusting consumed CPU/GPU time for one user or account with an explicitly signed delta.
@@ -52,7 +52,7 @@ The solution allows setting GPU load factors. This is a multiplicative coefficie
 
 The `slurm-quota set-gpu-factor` command allows configuring load factors by GPU type (restricted to root). The `slurm-quota gpu-factors` command displays the currently configured GPU load factors.
 
-The `slurm-quota serve` command starts a small HTTP/JSON server designed to work with systemd "socket activation". A `slurm-quota.socket` socket unit listens on TCP port 9911 and launches the `slurm-quota.service` service on demand upon the first connection. The server can automatically stops after a configurable period of inactivity (10 minutes by default). The API exposes a single `/stats` route that returns a JSON object of the form `{ users: [...], accounts: [...] }`. Optional query parameters can be used to filter responses: `username` filters users and limits accounts to this user's Slurm associations (e.g. `/stats?username=alice`), while `account` returns only the requested account stats in the `accounts` array (e.g. `/stats?account=hpc`).
+The `slurm-quota-serve` command starts a small HTTP/JSON server designed to work with systemd "socket activation". A `slurm-quota.socket` socket unit listens on TCP port 9911 and launches the `slurm-quota.service` service on demand upon the first connection. The server can automatically stops after a configurable period of inactivity (10 minutes by default). The API exposes a single `/stats` route that returns a JSON object of the form `{ users: [...], accounts: [...] }`. Optional query parameters can be used to filter responses: `username` filters users and limits accounts to this user's Slurm associations (e.g. `/stats?username=alice`), while `account` returns only the requested account stats in the `accounts` array (e.g. `/stats?account=hpc`).
 
 The `slurm-quota stats` command consumes this HTTP/JSON API by default (URL configurable via the `SLURM_QUOTA_URL` environment variable, default `http://127.0.0.1:9911/`). It queries `/stats` and displays a readable table in the terminal. By specifying a user (`--user` or positional username), an account (`--account`), or the `--all` option, the command transmits the appropriate filters to the service. User and account selectors are mutually exclusive. If the service is not available or in case of connection failure to the server, execution fails with an error message.
 
@@ -113,7 +113,7 @@ JobSubmitPlugins=lua
 AccountingStorageTRES=gres/gpu:<type1>,gres/gpu:<type2>
 ```
 
-The `AccountingStorageTRES` parameter enables recording of complementary resource allocations (e.g., GPU, licenses) in addition to generic resources (e.g., nodes, cores, memory) in the Slurm accounting database. It is necessary to enable tracking of all GPU types in the cluster so that the `slurm-quota charge` command can determine the GPUs allocated to completed jobs and account for the time consumed on these GPUs.
+The `AccountingStorageTRES` parameter enables recording of complementary resource allocations (e.g., GPU, licenses) in addition to generic resources (e.g., nodes, cores, memory) in the Slurm accounting database. It is necessary to enable tracking of all GPU types in the cluster so that the `slurm-quota-charge` command can determine the GPUs allocated to completed jobs and account for the time consumed on these GPUs.
 
 On compute/login nodes:
 
@@ -293,7 +293,7 @@ JobSubmitPlugins=lua
 AccountingStorageTRES=gres/gpu:<type1>,gres/gpu:<type2>
 ```
 
-The `AccountingStorageTRES` parameter enables recording of complementary resource allocations (e.g., GPU, licenses) in addition to generic resources (e.g., nodes, cores, memory) in the Slurm accounting database. It is necessary to enable tracking of all GPU types in the cluster so that the `slurm-quota charge` command can determine the GPUs allocated to completed jobs and account for the time consumed on these GPUs.
+The `AccountingStorageTRES` parameter enables recording of complementary resource allocations (e.g., GPU, licenses) in addition to generic resources (e.g., nodes, cores, memory) in the Slurm accounting database. It is necessary to enable tracking of all GPU types in the cluster so that the `slurm-quota-charge` command can determine the GPUs allocated to completed jobs and account for the time consumed on these GPUs.
 
 8) Logrotate configuration (recommended)
 
@@ -425,35 +425,6 @@ Note: `--account` is mutually exclusive with user selection (`--user` or positio
 Color display of the status bar can be disabled by setting the `NO_COLOR` environment variable.
 The `--hours` option changes only the displayed unit in the `stats` output; stored values and API values remain in minutes.
 
-- `serve`: Launches an HTTP JSON server to expose statistics via a REST API. Designed to work with systemd socket activation.
-
-Examples:
-
-```bash
-# Manual launch (testing)
-slurm-quota serve --host 127.0.0.1 --port 9911 --idle-timeout 600
-slurm-quota serve --host 127.0.0.1 --port 9911 --idle-timeout 0    # no idle timeout
-
-# Via systemd (recommended)
-sudo systemctl start slurm-quota.socket
-curl http://127.0.0.1:9911/health
-curl http://127.0.0.1:9911/stats
-curl http://127.0.0.1:9911/stats?username=alice
-curl http://127.0.0.1:9911/stats?account=hpc
-```
-
-The service automatically stops after a period of inactivity (600 seconds, ie. 10 minutes by default). This can be disabled with `--idle-timeout 0` argument. The `stats` command queries this HTTP service (URL configurable via the `SLURM_QUOTA_URL` environment variable).
-
-- `slurm-quota-web`: Starts the web dashboard with the built-in HTTP server (intended for local testing; production should use Apache/mod_wsgi or another WSGI server).
-
-Examples:
-
-```bash
-slurm-quota-web
-SLURM_QUOTA_WEB_HOST=0.0.0.0 SLURM_QUOTA_WEB_PORT=8080 slurm-quota-web
-SLURM_QUOTA_URL=http://controller:9911/ slurm-quota-web
-```
-
 - `user-quota` (restricted to root): Sets a CPU quota for a user.
 
 Examples:
@@ -562,7 +533,41 @@ sudo slurm-quota prune --accounts --account hpc  # prune only this eligible acco
 sudo slurm-quota prune --dry-run        # preview removals without applying them
 ```
 
-It is normally not necessary to execute this `prune` command under normal conditions. It may be useful in case of malfunction of the call to the `slurm-quota charge` command by Slurm. Its execution is nevertheless safe, it can be executed if in doubt about the preallocated durations assigned to users.
+It is normally not necessary to execute this `prune` command under normal conditions. It may be useful in case of malfunction of the call to the `slurm-quota-charge` command by Slurm. Its execution is nevertheless safe, it can be executed if in doubt about the preallocated durations assigned to users.
+
+
+### `slurm-quota-serve` Command
+
+Launches an HTTP REST API JSON server. Designed to work with systemd socket activation.
+
+Examples:
+
+```bash
+# Manual launch (testing)
+slurm-quota-serve --host 127.0.0.1 --port 9911 --idle-timeout 600
+slurm-quota-serve --host 127.0.0.1 --port 9911 --idle-timeout 0    # no idle timeout
+
+# Via systemd (recommended)
+sudo systemctl start slurm-quota.socket
+curl http://127.0.0.1:9911/health
+curl http://127.0.0.1:9911/stats
+curl http://127.0.0.1:9911/stats?username=alice
+curl http://127.0.0.1:9911/stats?account=hpc
+```
+
+The service automatically stops after a period of inactivity (600 seconds, ie. 10 minutes by default). This can be disabled with `--idle-timeout 0` argument. The `stats` command queries this HTTP service (URL configurable via the `SLURM_QUOTA_URL` environment variable).
+
+### `slurm-quota-web` Command
+
+Launches web application:
+
+Examples:
+
+```bash
+slurm-quota-web
+SLURM_QUOTA_WEB_HOST=0.0.0.0 SLURM_QUOTA_WEB_PORT=8080 slurm-quota-web
+SLURM_QUOTA_URL=http://controller:9911/ slurm-quota-web
+```
 
 ## Upgrade
 
@@ -591,6 +596,8 @@ On all nodes:
 ```bash
 # Legacy manual binary/completion/manpage copies (RPM will reinstall managed files)
 sudo rm -f /usr/local/bin/slurm-quota
+sudo rm -f /usr/local/bin/slurm-quota-charge
+sudo rm -f /usr/local/bin/slurm-quota-serve
 sudo rm -f /usr/local/bin/slurm-quota-web
 sudo rm -f /etc/bash_completion.d/slurm-quota
 sudo rm -f /usr/local/share/man/man1/slurm-quota.1
@@ -666,12 +673,16 @@ sudo systemctl reload httpd
 Manpages are maintained in AsciiDoc format:
 
 - `man/slurm-quota.1.adoc` for `slurm-quota`
+- `man/slurm-quota-charge.1.adoc` for `slurm-quota-charge`
+- `man/slurm-quota-serve.1.adoc` for `slurm-quota-serve`
 - `man/slurm-quota-web.1.adoc` for `slurm-quota-web`
 
 To generate roff manpages from these files, use:
 
 ```bash
 asciidoctor -b manpage -o slurm-quota.1 man/slurm-quota.1.adoc
+asciidoctor -b manpage -o slurm-quota-charge.1 man/slurm-quota-charge.1.adoc
+asciidoctor -b manpage -o slurm-quota-serve.1 man/slurm-quota-serve.1.adoc
 asciidoctor -b manpage -o slurm-quota-web.1 man/slurm-quota-web.1.adoc
 ```
 
@@ -679,6 +690,8 @@ To preview generated files locally:
 
 ```bash
 man -l ./slurm-quota.1
+man -l ./slurm-quota-charge.1
+man -l ./slurm-quota-serve.1
 man -l ./slurm-quota-web.1
 ```
 
@@ -686,6 +699,8 @@ Optional user-local installation:
 
 ```bash
 install -Dm644 slurm-quota.1 ~/.local/share/man/man1/slurm-quota.1
+install -Dm644 slurm-quota-charge.1 ~/.local/share/man/man1/slurm-quota-charge.1
+install -Dm644 slurm-quota-serve.1 ~/.local/share/man/man1/slurm-quota-serve.1
 install -Dm644 slurm-quota-web.1 ~/.local/share/man/man1/slurm-quota-web.1
 ```
 
@@ -693,7 +708,7 @@ install -Dm644 slurm-quota-web.1 ~/.local/share/man/man1/slurm-quota-web.1
 
 ### Tests
 
-The repository includes unit tests under `tests/unit/` (one module per source module under `src/slurm_quota/`, with one `TestCase` class per function) and functional CLI tests under `tests/functional/` (one module per `slurm-quota` subcommand). They are standard `unittest.TestCase` classes; the recommended runner is **pytest** (as in CI), with optional coverage reports configured in `pyproject.toml`.
+The repository includes unit tests under `tests/unit/` (one module per source module under `src/slurm_quota/`, with one `TestCase` class per function) and functional CLI tests under `tests/functional/` (one module per command). They are standard `unittest.TestCase` classes; the recommended runner is **pytest** (as in CI), with optional coverage reports configured in `pyproject.toml`.
 
 From the repository root, use a virtual environment (recommended on distributions that restrict system-wide `pip`, e.g. PEP 668):
 

--- a/man/slurm-quota-charge.1.adoc
+++ b/man/slurm-quota-charge.1.adoc
@@ -1,0 +1,59 @@
+= slurm-quota-charge(1)
+:doctype: manpage
+:manmanual: Slurm Quota Charge
+:mansource: slurm-quota-charge
+:revnumber: 2.0.0
+:revdate: 2026-04-20
+
+== Name
+
+slurm-quota-charge - update consumed CPU/GPU minutes on Slurm job completion
+
+== Synopsis
+
+*slurm-quota-charge* [*-h*] [*--debug* | *-q* | *--quiet*] [*--version*]
+
+== Description
+
+*slurm-quota-charge* updates consumed CPU/GPU minutes for a completed job using
+Slurm job completion environment variables and `sacct`. This command is designed
+to be executed by Slurm as a JobCompType=jobcomp/script with the `slurm` system
+user.
+
+The database path is fixed to `/var/lib/state/slurm-quota/slurm-quota.db`.
+
+== Options
+
+*-h*, *--help*::
+  Show help and exit.
+
+*--debug*::
+  Enable debug output.
+
+*-q*, *--quiet*::
+  Only print errors and warnings.
+
+*--version*::
+  Show program version and exit.
+
+== Environment
+
+*JOBID*, *ARRAYJOBID*, *ARRAYTASKID*, *USERNAME*, *ACCOUNT*, *PROCS*, *START*, *END*::
+  Used to compute job identity and consumed CPU minutes.
+
+== Files
+
+`/var/lib/state/slurm-quota/slurm-quota.db`::
+  SQLite database for quotas, consumed/preallocated counters, GPU factors, and default settings.
+
+== Exit Status
+
+*0*::
+  Success.
+
+*1*::
+  Runtime/permission/operational error.
+
+== See Also
+
+`slurm-quota(1)`, `sacct(1)`, `slurmctld(8)`

--- a/man/slurm-quota-serve.1.adoc
+++ b/man/slurm-quota-serve.1.adoc
@@ -1,0 +1,80 @@
+= slurm-quota-serve(1)
+:doctype: manpage
+:manmanual: Slurm Quota HTTP Service
+:mansource: slurm-quota-serve
+:revnumber: 2.0.0
+:revdate: 2026-04-20
+
+== Name
+
+slurm-quota-serve - HTTP JSON API for Slurm quota
+
+== Synopsis
+
+*slurm-quota-serve* [*-h*] [*--debug* | *-q* | *--quiet*] [*--version*] [*--host* <host>] [*--port* <port>] [*--idle-timeout* <seconds>]
+
+== Description
+
+*slurm-quota-serve* runs an HTTP JSON service exposing `/health` and `/stats`.
+It is designed to work with systemd socket activation and is consumed by
+`slurm-quota stats` and `slurm-quota-web`.
+
+The database path is fixed to `/var/lib/state/slurm-quota/slurm-quota.db`.
+
+== Options
+
+*-h*, *--help*::
+  Show help and exit.
+
+*--debug*::
+  Enable debug output.
+
+*-q*, *--quiet*::
+  Only print errors and warnings.
+
+*--version*::
+  Show program version and exit.
+
+*--host* <host>::
+  Bind host when not socket-activated (default: `127.0.0.1`).
+
+*--port* <port>::
+  Bind port when not socket-activated (default: `9911`).
+
+*--idle-timeout* <seconds>::
+  Exit after inactivity (default: `600`). `0` disables idle shutdown.
+
+Notes:
+
+- If systemd socket activation is active (`LISTEN_PID`/`LISTEN_FDS`), inherited FD 3 is used and `--host`/`--port` are ignored.
+- The command exits with error if the database file does not exist.
+
+== Environment
+
+*LISTEN_PID*, *LISTEN_FDS*::
+  Used to detect systemd socket activation.
+
+== Examples
+
+....
+slurm-quota-serve --host 127.0.0.1 --port 9911 --idle-timeout 600
+curl http://127.0.0.1:9911/health
+curl http://127.0.0.1:9911/stats?username=alice
+....
+
+== Files
+
+`/var/lib/state/slurm-quota/slurm-quota.db`::
+  SQLite database for quotas, consumed/preallocated counters, GPU factors, and default settings.
+
+== Exit Status
+
+*0*::
+  Success.
+
+*1*::
+  Runtime/permission/operational error.
+
+== See Also
+
+`slurm-quota(1)`, `slurm-quota-web(1)`, `systemd.socket(5)`

--- a/man/slurm-quota-web.1.adoc
+++ b/man/slurm-quota-web.1.adoc
@@ -19,7 +19,7 @@ slurm-quota-web - HTTP server for Slurm quota statistics web dashboard
 statistics in HTML web dashboard.
 
 The dashboard is read-only and consumes the existing `slurm-quota` HTTP API
-(`/stats`) exposed by `slurm-quota serve`.
+(`/stats`) exposed by `slurm-quota-serve`.
 
 == Environment
 
@@ -67,4 +67,4 @@ SLURM_QUOTA_WEB_HOST=0.0.0.0 SLURM_QUOTA_WEB_PORT=8080 slurm-quota-web
 
 == See Also
 
-`slurm-quota(1)`, `httpd(8)`, `mod_wsgi(8)`, `systemd.service(5)`
+`slurm-quota(1)`, `slurm-quota-serve(1)`, `httpd(8)`, `mod_wsgi(8)`, `systemd.service(5)`

--- a/man/slurm-quota.1.adoc
+++ b/man/slurm-quota.1.adoc
@@ -16,8 +16,8 @@ slurm-quota - manage Slurm CPU/GPU quota accounting, limits, and stats
 == Description
 
 *slurm-quota* manages CPU and GPU minute quotas for Slurm users and accounts.
-It updates consumed resources, configures quota and GPU charging settings, prunes
-unused data, and can expose a JSON API used by the `stats` command.
+It configures quota and GPU charging settings, prunes unused data, and displays
+statistics from the HTTP service started by `slurm-quota-serve`.
 
 The database path is fixed to `/var/lib/state/slurm-quota/slurm-quota.db`.
 
@@ -36,14 +36,6 @@ The database path is fixed to `/var/lib/state/slurm-quota/slurm-quota.db`.
   Show program version and exit.
 
 == Commands
-
-=== charge
-
-*slurm-quota charge*
-
-Update consumed CPU/GPU minutes for a completed job using Slurm job completion
-environment variables and `sacct`. This command is designed to be executed by
-Slurm as a JobCompType=jobcomp/script with `slurm` system user.
 
 === stats
 
@@ -257,36 +249,6 @@ sudo slurm-quota prune --accounts --account hpc
 sudo slurm-quota prune --all
 ....
 
-=== serve
-
-*slurm-quota serve* [*--host* <host>] [*--port* <port>] [*--idle-timeout* <seconds>]
-
-Run an HTTP JSON service exposing `/health` and `/stats`.
-
-Options:
-
-*--host* <host>::
-  Bind host when not socket-activated (default: `127.0.0.1`).
-
-*--port* <port>::
-  Bind port when not socket-activated (default: `9911`).
-
-*--idle-timeout* <seconds>::
-  Exit after inactivity (default: `600`). `0` disables idle shutdown.
-
-Notes:
-
-- If systemd socket activation is active (`LISTEN_PID`/`LISTEN_FDS`), inherited FD 3 is used and `--host`/`--port` are ignored.
-- The command exits with error if the database file does not exist.
-
-Examples:
-
-....
-slurm-quota serve --host 127.0.0.1 --port 9911 --idle-timeout 600
-curl http://127.0.0.1:9911/health
-curl http://127.0.0.1:9911/stats?username=alice
-....
-
 == Environment
 
 *SLURM_QUOTA_URL*::
@@ -299,12 +261,6 @@ curl http://127.0.0.1:9911/stats?username=alice
 *SLURM_QUOTA_WEB_ASSETS_DIR*, *SLURM_QUOTA_WEB_HOST*, *SLURM_QUOTA_WEB_PORT*::
   Optional variables used by `slurm-quota-web` to locate templates/static assets
   and configure standalone test server bind host/port.
-
-*LISTEN_PID*, *LISTEN_FDS*::
-  Used by `serve` to detect systemd socket activation.
-
-*JOBID*, *ARRAYJOBID*, *ARRAYTASKID*, *USERNAME*, *ACCOUNT*, *PROCS*, *START*, *END*::
-  Used by `charge` to compute job identity and consumed CPU minutes.
 
 == Files
 
@@ -324,4 +280,4 @@ curl http://127.0.0.1:9911/stats?username=alice
 
 == See Also
 
-`slurm-quota-web(1)`, `sacct(1)`, `sacctmgr(1)`, `sbatch(1)`, `srun(1)`, `slurmctld(8)`, `systemd.socket(5)`
+`slurm-quota-charge(1)`, `slurm-quota-serve(1)`, `slurm-quota-web(1)`, `sacct(1)`, `sacctmgr(1)`, `sbatch(1)`, `srun(1)`, `slurmctld(8)`, `systemd.socket(5)`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ license = { text = "GPL-2.0-or-later" }
 
 [project.scripts]
 slurm-quota = "slurm_quota.cli:main"
+slurm-quota-charge = "slurm_quota.charge:main"
+slurm-quota-serve = "slurm_quota.serve:main"
 migrate-slurm-quota = "slurm_quota.migrate:main"
 slurm-quota-web = "slurm_quota.web:main"
 

--- a/slurm-quota-charge-wrapper
+++ b/slurm-quota-charge-wrapper
@@ -4,7 +4,7 @@
 # Copyright (c) 2025 Université de Montpellier
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# Wrapper script for the slurm-quota charge command, designed to be executed
+# Wrapper script for the slurm-quota-charge command, designed to be executed
 # by Slurm as a JobCompType=jobcomp/script. The wrapper is required because
 # Slurm cannot directly execute the slurm-quota command with arguments as a
 # JobCompType=jobcomp/script.
@@ -14,5 +14,5 @@
 # charge command, including errors.
 exec &>>/var/log/slurm/charge/slurm-quota-charge.log
 
-# Execute the slurm-quota charge command
-exec /usr/local/bin/slurm-quota charge "$@"
+# Execute the slurm-quota-charge command
+exec /usr/local/bin/slurm-quota-charge "$@"

--- a/slurm-quota.bash-completion
+++ b/slurm-quota.bash-completion
@@ -103,11 +103,6 @@ _slurm_quota() {
         return 0
     fi
 
-    # Intentionally do not autocomplete internal/service subcommands.
-    if [[ "$subcmd" == "charge" || "$subcmd" == "serve" ]]; then
-        return 0
-    fi
-
     case "$prev" in
         --user)
             COMPREPLY=($(_slurm_quota_complete_users "$cur"))
@@ -117,14 +112,14 @@ _slurm_quota() {
             COMPREPLY=($(_slurm_quota_complete_accounts "$cur"))
             return 0
             ;;
-        --minutes|--hours|--port|--idle-timeout|--host|--user-cpu|--user-gpu|--account-cpu|--account-gpu)
+        --minutes|--hours|--user-cpu|--user-gpu|--account-cpu|--account-gpu)
             return 0
             ;;
     esac
 
     local base_opts="-h --help --version"
     case "$subcmd" in
-        charge|gpu-factors|default-quotas)
+        gpu-factors|default-quotas)
             COMPREPLY=($(compgen -W "$base_opts" -- "$cur"))
             ;;
         stats)
@@ -158,9 +153,6 @@ _slurm_quota() {
             ;;
         prune)
             COMPREPLY=($(compgen -W "$base_opts --preallocs --users --accounts --all --dry-run --user --account" -- "$cur"))
-            ;;
-        serve)
-            COMPREPLY=($(compgen -W "$base_opts --host --port --idle-timeout" -- "$cur"))
             ;;
     esac
 

--- a/slurm-quota.service
+++ b/slurm-quota.service
@@ -6,7 +6,7 @@ PartOf=slurm-quota.socket
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/slurm-quota serve --idle-timeout=600
+ExecStart=/usr/local/bin/slurm-quota-serve --idle-timeout=600
 DynamicUser=yes
 NoNewPrivileges=yes
 LockPersonality=yes

--- a/src/slurm_quota/charge.py
+++ b/src/slurm_quota/charge.py
@@ -4,10 +4,12 @@
 
 """Charge command for Slurm job completion."""
 
+import argparse
 import logging
 import sys
 
-from slurm_quota import auth
+from slurm_quota import APP_VERSION, auth
+from slurm_quota.log import setup_logging
 from slurm_quota.database import init_database, update_user_and_account_resources
 from slurm_quota.slurm import get_job_info_from_environment
 
@@ -54,3 +56,35 @@ def charge_command() -> None:
     except Exception as e:
         logger.error(f"Charge command failed: {e}")
         sys.exit(1)
+
+
+def main() -> None:
+    """Main entry point for the slurm-quota-charge script."""
+    parser = argparse.ArgumentParser(
+        prog="slurm-quota-charge",
+        description="Update user resource consumption on Slurm job completion",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    log_level_group = parser.add_mutually_exclusive_group()
+    log_level_group.add_argument(
+        "--debug",
+        action="store_true",
+        help="Print debug output",
+    )
+    log_level_group.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Only print errors and warnings",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {APP_VERSION}",
+        help="Show program version and exit",
+    )
+
+    args = parser.parse_args()
+    setup_logging(debug=args.debug, quiet=args.quiet)
+    charge_command()

--- a/src/slurm_quota/cli.py
+++ b/src/slurm_quota/cli.py
@@ -9,7 +9,6 @@ import re
 import sys
 
 from slurm_quota import APP_VERSION
-from slurm_quota.charge import charge_command
 from slurm_quota.commands import (
     adjust_command,
     prune_command,
@@ -24,7 +23,6 @@ from slurm_quota.commands import (
     show_user_stats,
 )
 from slurm_quota.log import setup_logging
-from slurm_quota.serve import run_serve_command
 
 
 def parse_signed_int(value: str) -> int:
@@ -78,11 +76,6 @@ def main():
     )
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
-
-    # Charge command
-    subparsers.add_parser(
-        "charge", help="Update user resource consumption (for Slurm job completion)"
-    )
 
     # Stats command
     stats_parser = subparsers.add_parser(
@@ -268,37 +261,12 @@ def main():
         help="Limit accounts pruning to a specific account",
     )
 
-    # Serve command (HTTP JSON API for stats, designed for systemd socket activation)
-    serve_parser = subparsers.add_parser(
-        "serve",
-        help="Serve HTTP JSON API (socket-activated by systemd; falls back to host/port)",
-    )
-    serve_parser.add_argument(
-        "--host",
-        default="127.0.0.1",
-        help="Host to bind if not socket-activated (default: 127.0.0.1)",
-    )
-    serve_parser.add_argument(
-        "--port",
-        type=int,
-        default=9911,
-        help="Port to bind if not socket-activated (default: 9911)",
-    )
-    serve_parser.add_argument(
-        "--idle-timeout",
-        type=int,
-        default=600,
-        help="Exit after N seconds of inactivity (0 disables idle timeout; default: 600)",
-    )
-
     args = parser.parse_args()
 
     # Setup logging with selected log verbosity
     setup_logging(debug=args.debug, quiet=args.quiet)
 
-    if args.command == "charge":
-        charge_command()
-    elif args.command == "stats":
+    if args.command == "stats":
         if args.username and args.user:
             parser.error("stats: positional username and --user are mutually exclusive")
         selected_username = args.user or args.username
@@ -342,8 +310,6 @@ def main():
             user_filter=args.user,
             account_filter=args.account,
         )
-    elif args.command == "serve":
-        run_serve_command(args.host, args.port, args.idle_timeout)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/slurm_quota/serve.py
+++ b/src/slurm_quota/serve.py
@@ -4,6 +4,7 @@
 
 """HTTP JSON API server for stats."""
 
+import argparse
 import json
 
 import os
@@ -17,7 +18,9 @@ from typing import Any, Optional
 from urllib.parse import parse_qs, urlparse
 
 import slurm_quota
+from slurm_quota import APP_VERSION
 from slurm_quota.database import query_accounts_aggregate, query_users_aggregate
+from slurm_quota.log import setup_logging
 from slurm_quota import slurm as slurm_integration
 
 import logging
@@ -181,3 +184,52 @@ def run_serve_command(host: str, port: int, idle_timeout: int) -> None:
             httpd.server_close()
         except Exception:
             pass
+
+
+def main() -> None:
+    """Main entry point for the slurm-quota-serve script."""
+    parser = argparse.ArgumentParser(
+        prog="slurm-quota-serve",
+        description="Serve HTTP JSON API for Slurm quota",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    log_level_group = parser.add_mutually_exclusive_group()
+    log_level_group.add_argument(
+        "--debug",
+        action="store_true",
+        help="Print debug output",
+    )
+    log_level_group.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Only print errors and warnings",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {APP_VERSION}",
+        help="Show program version and exit",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind if not socket-activated (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=9911,
+        help="Port to bind if not socket-activated (default: 9911)",
+    )
+    parser.add_argument(
+        "--idle-timeout",
+        type=int,
+        default=600,
+        help="Exit after N seconds of inactivity (0 disables idle timeout; default: 600)",
+    )
+
+    args = parser.parse_args()
+    setup_logging(debug=args.debug, quiet=args.quiet)
+    run_serve_command(args.host, args.port, args.idle_timeout)

--- a/tests/functional/functional_base.py
+++ b/tests/functional/functional_base.py
@@ -10,7 +10,9 @@ from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 from urllib.parse import parse_qs, unquote, urlparse
 
-from slurm_quota.cli import main
+from slurm_quota.cli import main as cli_main
+from slurm_quota.charge import main as charge_main
+from slurm_quota.serve import main as serve_main
 
 from tests.test_support import SlurmQuotaTestCase
 
@@ -33,14 +35,22 @@ class FakeJsonUrlopenResponse:
 class FunctionalCLIBase(SlurmQuotaTestCase):
     """Base for one-command functional TestCase classes."""
 
-    def run_main(self, argv):
+    def run_cli_main(self, argv):
         with patch.object(sys, "argv", argv):
-            main()
+            cli_main()
 
-    def run_main_exit(self, argv, code=1):
+    def run_charge_main(self, argv):
+        with patch.object(sys, "argv", argv):
+            charge_main()
+
+    def run_serve_main(self, argv):
+        with patch.object(sys, "argv", argv):
+            serve_main()
+
+    def run_cli_main_exit(self, argv, code=1):
         with patch.object(sys, "argv", argv):
             with self.assertRaises(SystemExit) as cm:
-                main()
+                cli_main()
         self.assertEqual(cm.exception.code, code)
 
     @contextmanager

--- a/tests/functional/test_account_gpu_quota.py
+++ b/tests/functional/test_account_gpu_quota.py
@@ -14,7 +14,7 @@ class TestAccountGpuQuotaCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(
+                    self.run_cli_main(
                         ["slurm-quota", "account-gpu-quota", "genomics_facility", "200"]
                     )
         self.assertEqual(
@@ -34,7 +34,7 @@ class TestAccountGpuQuotaCommand(FunctionalCLIBase):
         self.update_settings(default_account_quota_cpu_minutes=6666)
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
-                self.run_main(
+                self.run_cli_main(
                     ["slurm-quota", "account-gpu-quota", "neuro_render", "80"]
                 )
         with self.db_connection() as conn:
@@ -59,7 +59,7 @@ class TestAccountGpuQuotaCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(
+                    self.run_cli_main(
                         ["slurm-quota", "account-gpu-quota", "weather_cluster", "200"]
                     )
         self.assertEqual(
@@ -77,7 +77,7 @@ class TestAccountGpuQuotaCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="slurm"):
             with self.assertLogs("slurm_quota", level="ERROR") as log_cm:
                 with self.assertRaises(SystemExit) as cm:
-                    self.run_main(
+                    self.run_cli_main(
                         ["slurm-quota", "account-gpu-quota", "legacy_archive", "200"]
                     )
         self.assertEqual(cm.exception.code, 1)

--- a/tests/functional/test_account_quota.py
+++ b/tests/functional/test_account_quota.py
@@ -14,7 +14,7 @@ class TestAccountQuotaCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(
+                    self.run_cli_main(
                         ["slurm-quota", "account-quota", "astrophysics", "-1"]
                     )
         self.assertEqual(
@@ -34,7 +34,7 @@ class TestAccountQuotaCommand(FunctionalCLIBase):
         self.update_settings(default_account_quota_gpu_minutes=3333)
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
-                self.run_main(
+                self.run_cli_main(
                     ["slurm-quota", "account-quota", "molecular_dynamics", "50"]
                 )
         with self.db_connection() as conn:
@@ -59,7 +59,7 @@ class TestAccountQuotaCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(
+                    self.run_cli_main(
                         ["slurm-quota", "account-quota", "oceanography", "-1"]
                     )
         self.assertEqual(
@@ -77,7 +77,9 @@ class TestAccountQuotaCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="slurm"):
             with self.assertLogs("slurm_quota", level="ERROR") as log_cm:
                 with self.assertRaises(SystemExit) as cm:
-                    self.run_main(["slurm-quota", "account-quota", "reserved_io", "-1"])
+                    self.run_cli_main(
+                        ["slurm-quota", "account-quota", "reserved_io", "-1"]
+                    )
         self.assertEqual(cm.exception.code, 1)
         self.assertEqual(
             log_cm.output,

--- a/tests/functional/test_adjust.py
+++ b/tests/functional/test_adjust.py
@@ -14,7 +14,7 @@ class TestAdjustCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="slurm"):
             with self.assertLogs("slurm_quota", level="ERROR") as log_cm:
                 with self.assertRaises(SystemExit) as cm:
-                    self.run_main(
+                    self.run_cli_main(
                         [
                             "slurm-quota",
                             "adjust",
@@ -45,7 +45,7 @@ class TestAdjustCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(
+                    self.run_cli_main(
                         [
                             "slurm-quota",
                             "adjust",
@@ -81,7 +81,7 @@ class TestAdjustCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(
+                    self.run_cli_main(
                         [
                             "slurm-quota",
                             "adjust",
@@ -117,7 +117,7 @@ class TestAdjustCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(
+                    self.run_cli_main(
                         [
                             "slurm-quota",
                             "adjust",
@@ -143,7 +143,7 @@ class TestAdjustCommand(FunctionalCLIBase):
         self.assertEqual(row, (0,))
 
     def test_adjust_rejects_unsigned_delta(self):
-        self.run_main_exit(
+        self.run_cli_main_exit(
             [
                 "slurm-quota",
                 "adjust",
@@ -162,7 +162,7 @@ class TestAdjustCommand(FunctionalCLIBase):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.assertLogs("slurm_quota", level="ERROR") as log_cm:
                     with self.assertRaises(SystemExit) as cm:
-                        self.run_main(
+                        self.run_cli_main(
                             [
                                 "slurm-quota",
                                 "adjust",

--- a/tests/functional/test_charge.py
+++ b/tests/functional/test_charge.py
@@ -1,4 +1,4 @@
-"""Functional tests: `charge` subcommand."""
+"""Functional tests: `slurm-quota-charge` command."""
 
 from __future__ import annotations
 
@@ -53,7 +53,7 @@ class TestChargeCommand(FunctionalCLIBase):
                     "slurm_quota.slurm.get_job_info_from_sacct",
                     return_value=(None, None),
                 ):
-                    self.run_main(["slurm-quota", "charge"])
+                    self.run_charge_main(["slurm-quota-charge"])
         self.assertEqual(
             log_cm.output,
             [
@@ -103,7 +103,7 @@ class TestChargeCommand(FunctionalCLIBase):
                     "slurm_quota.slurm.get_job_info_from_sacct",
                     return_value=(None, None),
                 ):
-                    self.run_main(["slurm-quota", "charge"])
+                    self.run_charge_main(["slurm-quota-charge"])
         self.assertEqual(
             log_cm.output,
             [
@@ -144,7 +144,7 @@ class TestChargeCommand(FunctionalCLIBase):
                     "slurm_quota.slurm.get_job_info_from_sacct",
                     return_value=(None, None),
                 ):
-                    self.run_main(["slurm-quota", "charge"])
+                    self.run_charge_main(["slurm-quota-charge"])
         self.assertTrue(os.path.exists(self.db_path))
         self.assertEqual(
             log_cm.output,
@@ -188,7 +188,7 @@ class TestChargeCommand(FunctionalCLIBase):
                     "slurm_quota.slurm.get_job_info_from_sacct",
                     return_value=(job_uuid, None),
                 ):
-                    self.run_main(["slurm-quota", "charge"])
+                    self.run_charge_main(["slurm-quota-charge"])
         self.assertEqual(
             log_cm.output,
             [
@@ -217,7 +217,7 @@ class TestChargeCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with self.assertLogs("slurm_quota", level="ERROR") as log_cm:
                 with self.assertRaises(SystemExit) as cm:
-                    self.run_main(["slurm-quota", "charge"])
+                    self.run_charge_main(["slurm-quota-charge"])
         self.assertEqual(cm.exception.code, 1)
         self.assertEqual(
             log_cm.output,

--- a/tests/functional/test_default_quotas.py
+++ b/tests/functional/test_default_quotas.py
@@ -13,7 +13,7 @@ from tests.functional.functional_base import FunctionalCLIBase
 class TestDefaultQuotasCommand(FunctionalCLIBase):
     def test_default_quotas_initializes_db_and_prints_defaults(self):
         with self.capture_stdout() as out:
-            self.run_main(["slurm-quota", "default-quotas"])
+            self.run_cli_main(["slurm-quota", "default-quotas"])
         self.assertEqual(
             out.getvalue(),
             dedent(
@@ -38,7 +38,7 @@ class TestDefaultQuotasCommand(FunctionalCLIBase):
             default_account_quota_gpu_minutes=400,
         )
         with self.capture_stdout() as out:
-            self.run_main(["slurm-quota", "default-quotas"])
+            self.run_cli_main(["slurm-quota", "default-quotas"])
         self.assertEqual(
             out.getvalue(),
             dedent(
@@ -62,7 +62,7 @@ class TestDefaultQuotasCommand(FunctionalCLIBase):
             default_account_quota_gpu_minutes=42,
         )
         with self.capture_stdout() as out:
-            self.run_main(["slurm-quota", "default-quotas"])
+            self.run_cli_main(["slurm-quota", "default-quotas"])
         self.assertEqual(
             out.getvalue(),
             dedent(

--- a/tests/functional/test_gpu_factors.py
+++ b/tests/functional/test_gpu_factors.py
@@ -10,7 +10,7 @@ from tests.functional.functional_base import FunctionalCLIBase
 class TestGpuFactorsCommand(FunctionalCLIBase):
     def test_gpu_factors_without_database(self):
         with self.capture_stdout() as out:
-            self.run_main(["slurm-quota", "gpu-factors"])
+            self.run_cli_main(["slurm-quota", "gpu-factors"])
         self.assertIn("Database not found", out.getvalue())
 
     def test_gpu_factors_with_rows(self):
@@ -22,5 +22,5 @@ class TestGpuFactorsCommand(FunctionalCLIBase):
             )
             conn.commit()
         with self.capture_stdout() as out:
-            self.run_main(["slurm-quota", "gpu-factors"])
+            self.run_cli_main(["slurm-quota", "gpu-factors"])
         self.assertIn("a100", out.getvalue())

--- a/tests/functional/test_main.py
+++ b/tests/functional/test_main.py
@@ -9,12 +9,12 @@ from tests.functional.functional_base import FunctionalCLIBase
 
 class TestMain(FunctionalCLIBase):
     def test_no_subcommand_exits_with_help(self):
-        self.run_main_exit(["slurm-quota"], 1)
+        self.run_cli_main_exit(["slurm-quota"], 1)
 
     def test_version_option_prints_version_and_exits_zero(self):
         with self.capture_stdout() as stdout:
-            self.run_main_exit(["slurm-quota", "--version"], 0)
+            self.run_cli_main_exit(["slurm-quota", "--version"], 0)
         self.assertEqual(stdout.getvalue().strip(), f"slurm-quota {APP_VERSION}")
 
     def test_global_debug_and_quiet_are_mutually_exclusive(self):
-        self.run_main_exit(["slurm-quota", "--debug", "--quiet", "prune"], 2)
+        self.run_cli_main_exit(["slurm-quota", "--debug", "--quiet", "prune"], 2)

--- a/tests/functional/test_prune.py
+++ b/tests/functional/test_prune.py
@@ -16,14 +16,14 @@ class TestPruneCommand(FunctionalCLIBase):
         for left, right in combinations(selectors, 2):
             with self.subTest(left=left, right=right):
                 with self.assertRaises(SystemExit) as cm:
-                    self.run_main(["slurm-quota", "prune", left, right])
+                    self.run_cli_main(["slurm-quota", "prune", left, right])
                 self.assertEqual(cm.exception.code, 2)
 
     def test_prune_rejects_non_root(self):
         with patch("slurm_quota.auth.get_current_user", return_value="slurm"):
             with self.assertLogs("slurm_quota", level="ERROR") as log_cm:
                 with self.assertRaises(SystemExit) as cm:
-                    self.run_main(["slurm-quota", "prune"])
+                    self.run_cli_main(["slurm-quota", "prune"])
         self.assertEqual(cm.exception.code, 1)
         self.assertEqual(
             log_cm.output,
@@ -80,7 +80,7 @@ class TestPruneCommand(FunctionalCLIBase):
             ):
                 with self.assertLogs("slurm_quota", level="INFO") as log_cm:
                     with self.capture_stdout() as out:
-                        self.run_main(["slurm-quota", "prune"])
+                        self.run_cli_main(["slurm-quota", "prune"])
         self.assertEqual(
             out.getvalue(),
             "Removed 1 orphan preallocation(s), 2 user(s), 2 account(s)\n",
@@ -147,7 +147,7 @@ class TestPruneCommand(FunctionalCLIBase):
                 return_value={"uuid-active"},
             ):
                 with self.capture_stdout() as out:
-                    self.run_main(["slurm-quota", "prune", "--preallocs"])
+                    self.run_cli_main(["slurm-quota", "prune", "--preallocs"])
         self.assertEqual(
             out.getvalue(),
             "Removed 1 orphan preallocation(s), 0 user(s), 0 account(s)\n",
@@ -186,7 +186,7 @@ class TestPruneCommand(FunctionalCLIBase):
             conn.commit()
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with self.capture_stdout() as out:
-                self.run_main(["slurm-quota", "prune", "--users"])
+                self.run_cli_main(["slurm-quota", "prune", "--users"])
         self.assertEqual(
             out.getvalue(),
             "Removed 0 orphan preallocation(s), 1 user(s), 0 account(s)\n",
@@ -223,7 +223,7 @@ class TestPruneCommand(FunctionalCLIBase):
             conn.commit()
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with self.capture_stdout() as out:
-                self.run_main(["slurm-quota", "prune", "--accounts"])
+                self.run_cli_main(["slurm-quota", "prune", "--accounts"])
         self.assertEqual(
             out.getvalue(),
             "Removed 0 orphan preallocation(s), 0 user(s), 1 account(s)\n",
@@ -270,7 +270,7 @@ class TestPruneCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with self.assertLogs("slurm_quota", level="ERROR") as log_cm:
                 with self.assertRaises(SystemExit) as cm:
-                    self.run_main(["slurm-quota", "prune", "--users"])
+                    self.run_cli_main(["slurm-quota", "prune", "--users"])
         self.assertEqual(cm.exception.code, 1)
         self.assertEqual(
             log_cm.output,
@@ -323,7 +323,7 @@ class TestPruneCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with self.assertLogs("slurm_quota", level="ERROR") as log_cm:
                 with self.assertRaises(SystemExit) as cm:
-                    self.run_main(["slurm-quota", "prune", "--accounts"])
+                    self.run_cli_main(["slurm-quota", "prune", "--accounts"])
         self.assertEqual(cm.exception.code, 1)
         self.assertEqual(
             log_cm.output,
@@ -381,7 +381,7 @@ class TestPruneCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with self.assertLogs("slurm_quota", level="INFO") as log_cm:
                 with self.capture_stdout() as out:
-                    self.run_main(["slurm-quota", "prune", "--users", "--dry-run"])
+                    self.run_cli_main(["slurm-quota", "prune", "--users", "--dry-run"])
         self.assertEqual(
             out.getvalue(),
             (
@@ -437,7 +437,9 @@ class TestPruneCommand(FunctionalCLIBase):
 
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with self.capture_stdout() as out:
-                self.run_main(["slurm-quota", "prune", "--users", "--user", "u_drop"])
+                self.run_cli_main(
+                    ["slurm-quota", "prune", "--users", "--user", "u_drop"]
+                )
         self.assertEqual(
             out.getvalue(),
             "Removed 0 orphan preallocation(s), 1 user(s), 0 account(s)\n",
@@ -464,7 +466,9 @@ class TestPruneCommand(FunctionalCLIBase):
 
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with self.capture_stdout() as out:
-                self.run_main(["slurm-quota", "prune", "--users", "--user", "u_busy"])
+                self.run_cli_main(
+                    ["slurm-quota", "prune", "--users", "--user", "u_busy"]
+                )
         self.assertEqual(out.getvalue(), "Nothing to prune\n")
         with self.db_connection() as conn:
             self.assertEqual(
@@ -494,7 +498,7 @@ class TestPruneCommand(FunctionalCLIBase):
 
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with self.capture_stdout() as out:
-                self.run_main(
+                self.run_cli_main(
                     ["slurm-quota", "prune", "--accounts", "--account", "a_drop"]
                 )
         self.assertEqual(
@@ -531,7 +535,7 @@ class TestPruneCommand(FunctionalCLIBase):
 
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with self.capture_stdout() as out:
-                self.run_main(
+                self.run_cli_main(
                     [
                         "slurm-quota",
                         "prune",
@@ -573,7 +577,7 @@ class TestPruneCommand(FunctionalCLIBase):
 
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with self.capture_stdout() as out:
-                self.run_main(
+                self.run_cli_main(
                     ["slurm-quota", "prune", "--accounts", "--account", "a_busy"]
                 )
         self.assertEqual(out.getvalue(), "Nothing to prune\n")
@@ -607,7 +611,7 @@ class TestPruneCommand(FunctionalCLIBase):
 
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with self.capture_stdout() as out:
-                self.run_main(
+                self.run_cli_main(
                     [
                         "slurm-quota",
                         "prune",
@@ -651,5 +655,5 @@ class TestPruneCommand(FunctionalCLIBase):
                 return_value={"uuid-active"},
             ):
                 with self.capture_stdout() as out:
-                    self.run_main(["slurm-quota", "prune", "--preallocs"])
+                    self.run_cli_main(["slurm-quota", "prune", "--preallocs"])
         self.assertEqual(out.getvalue(), "Nothing to prune\n")

--- a/tests/functional/test_serve.py
+++ b/tests/functional/test_serve.py
@@ -1,4 +1,4 @@
-"""Functional tests: `serve` subcommand (`--host`, `--port`, `--idle-timeout`)."""
+"""Functional tests: `slurm-quota-serve` command (`--host`, `--port`, `--idle-timeout`)."""
 
 from __future__ import annotations
 
@@ -25,11 +25,10 @@ class TestServeCommand(FunctionalCLIBase):
         self, host: str, port: int, idle_timeout: int = 1
     ) -> threading.Thread:
         thread = threading.Thread(
-            target=self.run_main,
+            target=self.run_serve_main,
             args=(
                 [
-                    "slurm-quota",
-                    "serve",
+                    "slurm-quota-serve",
                     "--host",
                     host,
                     "--port",
@@ -290,11 +289,10 @@ class TestServeCommand(FunctionalCLIBase):
         host = "127.0.0.1"
         port = self._free_tcp_port()
         thread = threading.Thread(
-            target=self.run_main,
+            target=self.run_serve_main,
             args=(
                 [
-                    "slurm-quota",
-                    "serve",
+                    "slurm-quota-serve",
                     "--host",
                     host,
                     "--port",

--- a/tests/functional/test_set_default_quotas.py
+++ b/tests/functional/test_set_default_quotas.py
@@ -15,7 +15,7 @@ class TestSetDefaultQuotasCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(
+                    self.run_cli_main(
                         [
                             "slurm-quota",
                             "set-default-quotas",
@@ -51,7 +51,7 @@ class TestSetDefaultQuotasCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(
+                    self.run_cli_main(
                         ["slurm-quota", "set-default-quotas", "--user-cpu", "999"]
                     )
         self.assertEqual(
@@ -70,7 +70,7 @@ class TestSetDefaultQuotasCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="slurm"):
             with self.assertLogs("slurm_quota", level="ERROR") as log_cm:
                 with self.assertRaises(SystemExit) as cm:
-                    self.run_main(
+                    self.run_cli_main(
                         [
                             "slurm-quota",
                             "set-default-quotas",
@@ -92,7 +92,7 @@ class TestSetDefaultQuotasCommand(FunctionalCLIBase):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.assertLogs("slurm_quota", level="ERROR") as log_cm:
                     with self.assertRaises(SystemExit) as cm:
-                        self.run_main(["slurm-quota", "set-default-quotas"])
+                        self.run_cli_main(["slurm-quota", "set-default-quotas"])
         self.assertEqual(cm.exception.code, 1)
         self.assertEqual(
             log_cm.output,

--- a/tests/functional/test_set_gpu_factor.py
+++ b/tests/functional/test_set_gpu_factor.py
@@ -12,9 +12,9 @@ class TestSetGpuFactorCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(["slurm-quota", "set-gpu-factor", "h100", "0.25"])
+                    self.run_cli_main(["slurm-quota", "set-gpu-factor", "h100", "0.25"])
                 self.assertIn("h100", out.getvalue())
 
     def test_set_gpu_factor_non_positive_exits(self):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
-            self.run_main_exit(["slurm-quota", "set-gpu-factor", "x", "0"], 1)
+            self.run_cli_main_exit(["slurm-quota", "set-gpu-factor", "x", "0"], 1)

--- a/tests/functional/test_stats.py
+++ b/tests/functional/test_stats.py
@@ -48,7 +48,7 @@ class TestStatsCommand(FunctionalCLIBase):
             current_user_ctx,
             self.capture_stdout() as out,
         ):
-            self.run_main(argv)
+            self.run_cli_main(argv)
         self.assertEqual(out.getvalue(), expected)
 
     def test_stats_uses_current_user_when_username_omitted(self):
@@ -314,12 +314,12 @@ class TestStatsCommand(FunctionalCLIBase):
         )
 
     def test_stats_rejects_positional_and_user_option(self):
-        self.run_main_exit(["slurm-quota", "stats", "alice", "--user", "bob"], 2)
+        self.run_cli_main_exit(["slurm-quota", "stats", "alice", "--user", "bob"], 2)
 
     def test_stats_rejects_user_and_account_options(self):
-        self.run_main_exit(
+        self.run_cli_main_exit(
             ["slurm-quota", "stats", "--user", "alice", "--account", "hpc"], 2
         )
 
     def test_stats_rejects_positional_and_account_options(self):
-        self.run_main_exit(["slurm-quota", "stats", "alice", "--account", "hpc"], 2)
+        self.run_cli_main_exit(["slurm-quota", "stats", "alice", "--account", "hpc"], 2)

--- a/tests/functional/test_user_gpu_quota.py
+++ b/tests/functional/test_user_gpu_quota.py
@@ -14,7 +14,7 @@ class TestUserGpuQuotaCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(["slurm-quota", "user-gpu-quota", "liam", "100"])
+                    self.run_cli_main(["slurm-quota", "user-gpu-quota", "liam", "100"])
         self.assertEqual(
             out.getvalue(),
             "Successfully set GPU quota for user liam: 100 GPU minutes\n",
@@ -32,7 +32,7 @@ class TestUserGpuQuotaCommand(FunctionalCLIBase):
         self.update_settings(default_user_quota_cpu_minutes=5151)
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
-                self.run_main(["slurm-quota", "user-gpu-quota", "amara", "200"])
+                self.run_cli_main(["slurm-quota", "user-gpu-quota", "amara", "200"])
         with self.db_connection() as conn:
             row = conn.execute(
                 "SELECT quota_cpu_minutes, quota_gpu_minutes FROM users WHERE username = ?",
@@ -55,7 +55,7 @@ class TestUserGpuQuotaCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(["slurm-quota", "user-gpu-quota", "noah", "100"])
+                    self.run_cli_main(["slurm-quota", "user-gpu-quota", "noah", "100"])
         self.assertEqual(
             out.getvalue(),
             "Successfully set GPU quota for user noah: 100 GPU minutes\n",
@@ -71,7 +71,7 @@ class TestUserGpuQuotaCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="slurm"):
             with self.assertLogs("slurm_quota", level="ERROR") as log_cm:
                 with self.assertRaises(SystemExit) as cm:
-                    self.run_main(["slurm-quota", "user-gpu-quota", "owen", "100"])
+                    self.run_cli_main(["slurm-quota", "user-gpu-quota", "owen", "100"])
         self.assertEqual(cm.exception.code, 1)
         self.assertEqual(
             log_cm.output,

--- a/tests/functional/test_user_quota.py
+++ b/tests/functional/test_user_quota.py
@@ -14,7 +14,7 @@ class TestUserQuotaCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(["slurm-quota", "user-quota", "elena", "500"])
+                    self.run_cli_main(["slurm-quota", "user-quota", "elena", "500"])
         self.assertEqual(
             out.getvalue(),
             "Successfully set quota for user elena: 500 CPU minutes\n",
@@ -32,7 +32,7 @@ class TestUserQuotaCommand(FunctionalCLIBase):
         self.update_settings(default_user_quota_gpu_minutes=4242)
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
-                self.run_main(["slurm-quota", "user-quota", "marcus", "500"])
+                self.run_cli_main(["slurm-quota", "user-quota", "marcus", "500"])
         with self.db_connection() as conn:
             row = conn.execute(
                 "SELECT quota_cpu_minutes, quota_gpu_minutes FROM users WHERE username = ?",
@@ -55,7 +55,7 @@ class TestUserQuotaCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="root"):
             with patch("slurm_quota.database.set_database_permissions"):
                 with self.capture_stdout() as out:
-                    self.run_main(["slurm-quota", "user-quota", "sofia", "500"])
+                    self.run_cli_main(["slurm-quota", "user-quota", "sofia", "500"])
         self.assertEqual(
             out.getvalue(),
             "Successfully set quota for user sofia: 500 CPU minutes\n",
@@ -71,7 +71,7 @@ class TestUserQuotaCommand(FunctionalCLIBase):
         with patch("slurm_quota.auth.get_current_user", return_value="nobody"):
             with self.assertLogs("slurm_quota", level="ERROR") as log_cm:
                 with self.assertRaises(SystemExit) as cm:
-                    self.run_main(["slurm-quota", "user-quota", "taylor", "1"])
+                    self.run_cli_main(["slurm-quota", "user-quota", "taylor", "1"])
         self.assertEqual(cm.exception.code, 1)
         self.assertEqual(
             log_cm.output,


### PR DESCRIPTION
These commands are not designed to be run by end-users and operators, create dedicated executable endpoint for integration in services and wrappers.